### PR TITLE
[LOGGING-5264] Add sign step to the workflow

### DIFF
--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   TAG: ${{ github.event.release.tag_name }}
-  GPG_MAIL: 'infrastructure-eng@newrelic.com'
+  GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
   AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"

--- a/.github/workflows/prerelease_linux.yml
+++ b/.github/workflows/prerelease_linux.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   TAG: ${{ github.event.release.tag_name }}
+  GPG_MAIL: 'infrastructure-eng@newrelic.com'
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
   AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
@@ -16,6 +17,19 @@ env:
   AWS_REGION: "us-east-1"
 
 jobs:
+  sign:
+    name: Sign
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Sign artifacts
+        run: |
+          apt update
+          apt install -y gpg rpm debsigs
+          bash scripts/sign.sh
+
   publishing-to-s3:
     name: Publish linux artifacts into s3 test bucket
     runs-on: ubuntu-20.04

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   TAG: ${{ github.event.release.tag_name }}
+  GPG_MAIL: 'infrastructure-eng@newrelic.com'
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
   AWS_S3_BUCKET_NAME: "nr-downloads-main"
@@ -16,6 +17,19 @@ env:
   AWS_REGION: "us-east-1"
 
 jobs:
+  sign:
+    name: Sign
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Sign artifacts
+        run: |
+          apt update
+          apt install -y gpg rpm debsigs
+          bash scripts/sign.sh
+
   publishing-to-s3:
     name: Publish linux artifacts into s3 test bucket
     runs-on: ubuntu-20.04

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   TAG: ${{ github.event.release.tag_name }}
-  GPG_MAIL: 'infrastructure-eng@newrelic.com'
+  GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
   AWS_S3_BUCKET_NAME: "nr-downloads-main"

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -e
+#
+#
+#
+# Sign/Resign RPM's & DEB's in /dist artifacts to GH Release Assets
+#
+#
+#
+
+# Sign RPM's
+echo "===> Create .rpmmacros to sign rpm's from Goreleaser"
+echo "%_gpg_name ${GPG_MAIL}" >> ~/.rpmmacros
+echo "%_signature gpg" >> ~/.rpmmacros
+echo "%_gpg_path /root/.gnupg" >> ~/.rpmmacros
+echo "%_gpgbin /usr/bin/gpg" >> ~/.rpmmacros
+echo "%__gpg_sign_cmd   %{__gpg} gpg --no-verbose --no-armor --batch --pinentry-mode loopback --passphrase ${GPG_PASSPHRASE} --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
+echo "===> Importing GPG private key from GHA secrets..."
+printf %s ${GPG_PRIVATE_KEY_BASE64} | base64 -d | gpg --batch --import -
+
+echo "===> Importing GPG signature, needed from Goreleaser to verify signature"
+gpg --export -a ${GPG_MAIL} > /tmp/RPM-GPG-KEY-${GPG_MAIL}
+rpm --import /tmp/RPM-GPG-KEY-${GPG_MAIL}
+
+echo "===> List keys"
+rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n'
+
+for rpm_file in $(find -regex ".*\.\(rpm\)");do
+  echo "===> Signing $rpm_file"
+  rpm --resign $rpm_file
+  echo "===> Sign verification $rpm_file"
+  rpm -v --checksig $rpm_file
+done
+
+# Sign DEB's
+GNUPGHOME="/root/.gnupg"
+echo "${GPG_PASSPHRASE}" > "${GNUPGHOME}/gpg-passphrase"
+echo "passphrase-file ${GNUPGHOME}/gpg-passphrase" >> "$GNUPGHOME/gpg.conf"
+echo 'allow-loopback-pinentry' >> "${GNUPGHOME}/gpg-agent.conf"
+echo 'pinentry-mode loopback' >> "${GNUPGHOME}/gpg.conf"
+echo 'use-agent' >> "${GNUPGHOME}/gpg.conf"
+echo RELOADAGENT | gpg-connect-agent
+
+for deb_file in $(find -regex ".*\.\(deb\)");do
+  echo "===> Signing $deb_file"
+  debsigs --sign=origin --verify --check -v -k ${GPG_MAIL} $deb_file
+done


### PR DESCRIPTION
Add a new sign step to the release and prerelease workflows that will be in charge of sign provided rpm/deb files before upload them to S3