### PR TITLE
remove: unused versioning file

### DIFF
--- a/nr_fb_version
+++ b/nr_fb_version
@@ -1,3 +1,0 @@
-linux,1.7.4
-windows,1.7.4
-artifact,1.7.4


### PR DESCRIPTION
Now we use version from release candidate.