### PR TITLE
Remove unsupported OSs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -90,15 +90,12 @@ jobs:
         packages:
           - amd64/debian/buster
           - arm64/debian/buster
-          - amd64/debian/jessie
-          - arm64/debian/jessie
           - amd64/debian/stretch
           - arm64/debian/stretch
           - amd64/ubuntu/bionic
           - arm64/ubuntu/bionic
           - amd64/ubuntu/focal
           - arm64/ubuntu/focal
-          - amd64/ubuntu/xenial
 
     steps:
       - name: Check out repository

--- a/schemas/fb-linux.yml
+++ b/schemas/fb-linux.yml
@@ -9,18 +9,7 @@
       dest: "{dest_prefix}linux/apt/"
       os_version:
         - buster
-        - jessie
         - stretch
-
-- src: "{app_name}_{version}_ubuntu-{os_version}_{arch}.deb"
-  arch:
-    - amd64
-  uploads:
-    - type: apt
-      src_repo: "{access_point_host}/infrastructure_agent/linux/apt"
-      dest: "{dest_prefix}linux/apt/"
-      os_version:
-        - xenial
 
 - src: "{app_name}_{version}_ubuntu-{os_version}_{arch}.deb"
   arch:


### PR DESCRIPTION
Version 1.8.1 of FluentBit no longer supports:
 - Debian Jessie 
 - Ubuntu Xenial 
 
 We are removing those from the pipeline. 