### PR TITLE
feat: include suse 12.5 aws schema definition

### DIFF
--- a/schemas/fb-linux.yml
+++ b/schemas/fb-linux.yml
@@ -43,3 +43,12 @@
       dest: "{dest_prefix}linux/yum/amazonlinux/{os_version}/{arch}/"
       os_version:
         - 2
+
+- src: "{app_name}-{version}-1.sles{os_version}.{arch}.rpm"
+  arch:
+    - x86_64
+  uploads:
+    - type: zypp
+      dest: "{dest_prefix}linux/zypp/sles/{os_version}/{arch}/"
+      os_version:
+        - 12.5


### PR DESCRIPTION
**THIS IS A TEMPORARY CHANGE**

FB v1.8.6 will include a sles12.5 package compiled by NR.

In this PR we change the aws schema definition to upload this new package that was manually generated and uploaded in the  pre-release creation.

package name e.g: td-agent-bit-1.8.6-1.sles12.5.x86_64.rpm
dest: http://download.newrelic.com/infrastructure_agent/linux/zypp/sles/12.5/x86_64/