### PR TITLE
fix: include arm packages for centos 7 and 8

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -32,9 +32,9 @@ jobs:
           - x86_64/x86_64/amazonlinux/2
           - aarch64/arm64/amazonlinux/2
           - x86_64/x86_64/centos/7
-          #- aarch64/arm64/centos/7 https://github.com/fluent/fluent-bit/issues/3584
+          - aarch64/arm64/centos/7
           - x86_64/x86_64/centos/8
-          #- aarch64/arm64/centos/8 https://github.com/fluent/fluent-bit/issues/3584
+          - aarch64/arm64/centos/8
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Issue [FB#4270](https://github.com/fluent/fluent-bit/issues/4270) was solved.

Once [release candidate 1.9.0](https://github.com/fluent/fluent-bit/discussions/4954) is deployed we can upload new versions for arm/centos 7 and 8.

---
Test reference in [comment](https://github.com/fluent/fluent-bit/issues/4270#issuecomment-1063925022)