### PR TITLE
Fluent Bit 1.9.X is no longer available for Debian Stretch

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -92,8 +92,6 @@ jobs:
           - arm64/debian/bullseye
           - amd64/debian/buster
           - arm64/debian/buster
-          - amd64/debian/stretch
-          - arm64/debian/stretch
           - amd64/ubuntu/bionic
           - arm64/ubuntu/bionic
           - amd64/ubuntu/focal

--- a/schemas/fb-linux.yml
+++ b/schemas/fb-linux.yml
@@ -10,7 +10,6 @@
       os_version:
         - bullseye
         - buster
-        - stretch
 
 - src: "{app_name}_{version}_ubuntu-{os_version}_{arch}.deb"
   arch:


### PR DESCRIPTION
Removes Debian Stretch from the distribution matrix, since Fluent Bit 1.9.X [stopped giving support for this distribution](https://docs.fluentbit.io/manual/installation/supported-platforms).