### PR TITLE
fix: windows zip binary

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -166,9 +166,9 @@ jobs:
       - name: Download FB for windows & create artifact
         run: |
           FB_MAJOR_MINOR_VERSION=$(cut -d. -f1-2 <<< "${{ env.version }}")
-          wget "http://fluentbit.io/releases/${FB_MAJOR_MINOR_VERSION}/td-agent-bit-${{ env.version }}-${{ env.app }}".zip
-          unzip td-agent-bit-${{ env.version }}-${{ env.app }}.zip
-          zip -r -j ~/packages/fb-windows-${{ env.arch }}.zip td-agent-bit-${{ env.version }}-${{ env.app }}/bin
+          wget "http://fluentbit.io/releases/${FB_MAJOR_MINOR_VERSION}/fluent-bit-${{ env.version }}-${{ env.app }}".zip
+          unzip fluent-bit-${{ env.version }}-${{ env.app }}.zip
+          zip -r -j ~/packages/fb-windows-${{ env.arch }}.zip fluent-bit-${{ env.version }}-${{ env.app }}/bin
         env:
           version: ${{ env.VERSION }}
           app: ${{ steps.app.outputs.version }}
@@ -176,7 +176,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: td-agent-bit_${{ env.version }}_zip
+          name: fluent-bit_${{ env.version }}_zip
           path: ~/packages/
         env:
           version: ${{ env.VERSION }}


### PR DESCRIPTION
Infra-agent use fluent-bit binary, since v1.9.1 provided url downloaded `td-agent-bit`; 

Change it to keep compatibility with infra-agent.


<img width="349" alt="Screen Shot 2022-04-13 at 17 53 47" src="https://user-images.githubusercontent.com/4612272/163220865-d68099c6-ebdc-410c-805a-25e9ce3c4f3d.png">
