### PR TITLE
fix: keep constant gh artifact names between windows and linux

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -176,7 +176,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: fluent-bit_${{ env.version }}_zip
+          name: td-agent-bit_${{ env.version }}_zip
           path: ~/packages/
         env:
           version: ${{ env.VERSION }}


### PR DESCRIPTION
GH Actions is failing because of the windows fluent-bit artifact name, so rolling it back to td-agent-bit to keep it the same as linux. This shouldn't affect to nothing else it's only the artifact name for gh, no the package or the binary name