### PR TITLE
Include only exe and dll files for windows zip package

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -168,7 +168,7 @@ jobs:
           FB_MAJOR_MINOR_VERSION=$(cut -d. -f1-2 <<< "${{ env.version }}")
           wget "http://fluentbit.io/releases/${FB_MAJOR_MINOR_VERSION}/fluent-bit-${{ env.version }}-${{ env.app }}".zip
           unzip fluent-bit-${{ env.version }}-${{ env.app }}.zip
-          zip -r -j ~/packages/fb-windows-${{ env.arch }}.zip fluent-bit-${{ env.version }}-${{ env.app }}/bin
+          zip -r -j ~/packages/fb-windows-${{ env.arch }}.zip fluent-bit-${{ env.version }}-${{ env.app }}/bin/fluent-bit.exe fluent-bit-${{ env.version }}-${{ env.app }}/bin/fluent-bit.dll
         env:
           version: ${{ env.VERSION }}
           app: ${{ steps.app.outputs.version }}


### PR DESCRIPTION
Looks like in the last FB version they've left a debug file `fluent-bit-1.9.3-win64/bin/fluent-bit.pdb` inside the zip increasing the zip file from 6.6Mb to 16M

This PR changes the windows zip generation step to only include the binary (fluent-bit.exe) and the DLL (fluent-bit.dll) instead of all files inside the original zip's bin folder.

<img width="581" alt="Screenshot 2022-05-11 at 18 30 42" src="https://user-images.githubusercontent.com/317362/167900956-ee7151c1-6189-4fed-9de9-8ccf78b31c01.png">
