### PR TITLE
Update to fluent-bit and make publish pre-release packages a manually triggered action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,6 +16,7 @@ env:
   AWS_REGION: "us-east-1"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   VERSION: ${{ github.event.release.tag_name }}
+  FB_PACKAGE_NAME: ${{ startsWith(github.event.release.tag_name, "1") && "td-agent-bit" || "fluent-bit" }}
 
 jobs:
   rpm:
@@ -61,8 +62,8 @@ jobs:
           distro: ${{ steps.fb.outputs.distro }}
 
       - name: Download and Rename binaries
-        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/${{ env.fb-arch }}/fluent-bit-${{ env.version }}-1.${{ env.fb-arch }}.rpm
-          -o packages/${{ env.version }}/${{ env.fb-distro }}/fluent-bit-${{ env.version }}-1.${{ env.nr-distro }}.${{ env.nr-arch }}.rpm
+        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/${{ env.fb-arch }}/${{ env.FB_PACKAGE_NAME }}-${{ env.version }}-1.${{ env.fb-arch }}.rpm
+          -o packages/${{ env.version }}/${{ env.fb-distro }}/${{ env.FB_PACKAGE_NAME }}-${{ env.version }}-1.${{ env.nr-distro }}.${{ env.nr-arch }}.rpm
         env:
           fb-arch: ${{ steps.fb.outputs.arch }}
           fb-distro: ${{ steps.fb.outputs.distro }}
@@ -77,7 +78,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: fluent-bit_${{ env.version }}_rpm
+          name: ${{ env.FB_PACKAGE_NAME }}_${{ env.version }}_rpm
           path: packages/
         env:
           version: ${{ env.VERSION }}
@@ -121,8 +122,8 @@ jobs:
           distro: ${{ steps.distros.outputs.fb }}
 
       - name: Download and Rename binaries
-        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/pool/main/t/fluent-bit/fluent-bit_${{ env.version }}_${{ env.arch }}.deb
-          -o packages/${{ env.version }}/${{ env.fb-distro }}/fluent-bit_${{ env.version }}_${{ env.nr-distro }}_${{ env.arch }}.deb
+        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/pool/main/t/${{ env.FB_PACKAGE_NAME }}/${{ env.FB_PACKAGE_NAME }}_${{ env.version }}_${{ env.arch }}.deb
+          -o packages/${{ env.version }}/${{ env.fb-distro }}/${{ env.FB_PACKAGE_NAME }}_${{ env.version }}_${{ env.nr-distro }}_${{ env.arch }}.deb
         env:
           fb-distro: ${{ steps.distros.outputs.fb }}
           nr-distro: ${{ steps.distros.outputs.nr }}
@@ -136,7 +137,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: fluent-bit_${{ env.version }}_deb
+          name: ${{ env.FB_PACKAGE_NAME }}_${{ env.version }}_deb
           path: packages/
         env:
           version: ${{ env.VERSION }}
@@ -196,7 +197,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: fluent-bit_${{ env.version }}_${{ env.type }}
+          name: ${{ env.FB_PACKAGE_NAME }}_${{ env.version }}_${{ env.type }}
           path: packages/${{ env.type }}
         env:
           version: ${{ env.VERSION }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   rpm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -61,8 +61,8 @@ jobs:
           distro: ${{ steps.fb.outputs.distro }}
 
       - name: Download and Rename binaries
-        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/${{ env.fb-arch }}/td-agent-bit-${{ env.version }}-1.${{ env.fb-arch }}.rpm
-          -o packages/${{ env.version }}/${{ env.fb-distro }}/td-agent-bit-${{ env.version }}-1.${{ env.nr-distro }}.${{ env.nr-arch }}.rpm
+        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/${{ env.fb-arch }}/fluent-bit-${{ env.version }}-1.${{ env.fb-arch }}.rpm
+          -o packages/${{ env.version }}/${{ env.fb-distro }}/fluent-bit-${{ env.version }}-1.${{ env.nr-distro }}.${{ env.nr-arch }}.rpm
         env:
           fb-arch: ${{ steps.fb.outputs.arch }}
           fb-distro: ${{ steps.fb.outputs.distro }}
@@ -77,13 +77,13 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: td-agent-bit_${{ env.version }}_rpm
+          name: fluent-bit_${{ env.version }}_rpm
           path: packages/
         env:
           version: ${{ env.VERSION }}
 
   deb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -121,8 +121,8 @@ jobs:
           distro: ${{ steps.distros.outputs.fb }}
 
       - name: Download and Rename binaries
-        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/pool/main/t/td-agent-bit/td-agent-bit_${{ env.version }}_${{ env.arch }}.deb
-          -o packages/${{ env.version }}/${{ env.fb-distro }}/td-agent-bit_${{ env.version }}_${{ env.nr-distro }}_${{ env.arch }}.deb
+        run: curl https://packages.fluentbit.io/${{ env.fb-distro }}/pool/main/t/fluent-bit/fluent-bit_${{ env.version }}_${{ env.arch }}.deb
+          -o packages/${{ env.version }}/${{ env.fb-distro }}/fluent-bit_${{ env.version }}_${{ env.nr-distro }}_${{ env.arch }}.deb
         env:
           fb-distro: ${{ steps.distros.outputs.fb }}
           nr-distro: ${{ steps.distros.outputs.nr }}
@@ -136,13 +136,13 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: td-agent-bit_${{ env.version }}_deb
+          name: fluent-bit_${{ env.version }}_deb
           path: packages/
         env:
           version: ${{ env.VERSION }}
 
   zip:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         packages:
@@ -176,13 +176,13 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: td-agent-bit_${{ env.version }}_zip
+          name: fluent-bit_${{ env.version }}_zip
           path: ~/packages/
         env:
           version: ${{ env.VERSION }}
 
   upload-assets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ rpm, deb, zip ]
     strategy:
       matrix:
@@ -196,7 +196,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: td-agent-bit_${{ env.version }}_${{ env.type }}
+          name: fluent-bit_${{ env.version }}_${{ env.type }}
           path: packages/${{ env.type }}
         env:
           version: ${{ env.VERSION }}
@@ -204,34 +204,3 @@ jobs:
 
       - name: Upload asset
         run: bash ./scripts/upload_assets_gh.sh
-
-  publishing-to-s3:
-    name: Publish linux artifacts into s3 test bucket
-    runs-on: ubuntu-20.04
-    needs: [ upload-assets ]
-    steps:
-      - name: Publish assets to S3 action
-        uses: newrelic/infrastructure-publish-action@v1.2.3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
-        with:
-          tag: ${{env.VERSION}}
-          app_name: "td-agent-bit"
-          repo_name: "newrelic/fluent-bit-package"
-          schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/fb-linux.yml"
-          aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-          access_point_host: "staging"
-          run_id: ${{ github.run_id }}
-          aws_region: ${{ env.AWS_REGION }}
-          aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}
-          aws_role_arn: ${{ env.AWS_ROLE_ARN }}
-          # used for signing package stuff
-          gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
-          gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}

--- a/.github/workflows/prerelease_linux_publish.yml
+++ b/.github/workflows/prerelease_linux_publish.yml
@@ -15,6 +15,7 @@ env:
   AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
   AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
   AWS_REGION: "us-east-1"
+  FB_PACKAGE_NAME: ${{ startsWith(github.event.release.tag_name, "1") && "td-agent-bit" || "fluent-bit" }}
 
 jobs:
   publishing-to-s3:
@@ -31,7 +32,7 @@ jobs:
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
           tag: ${{env.VERSION}}
-          app_name: "fluent-bit"
+          app_name: ${{env.FB_PACKAGE_NAME}}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/fb-linux.yml"

--- a/.github/workflows/prerelease_linux_publish.yml
+++ b/.github/workflows/prerelease_linux_publish.yml
@@ -1,4 +1,4 @@
-name: Staged pre-release publish for Linux
+name: Pre-release publish for Linux
 
 on:
   workflow_dispatch:
@@ -6,15 +6,6 @@ on:
       tag:
         description: 'Tag to pre-release'
         required: true
-      schema:
-        description: 'Schema to be pre-released'
-        required: true
-        options:
-          - fb-amazonlinux
-          - fb-centos
-          - fb-debian
-          - fb-sles
-          - fb-ubuntu
 
 env:
   TAG: ${{ github.event.inputs.tag }}
@@ -26,12 +17,12 @@ env:
   AWS_REGION: "us-east-1"
 
 jobs:
-  publishing-to-s3-linux:
-    name: Publish linux artifacts into s3 staging bucket
+  publishing-to-s3:
+    name: Publish linux artifacts into s3 test bucket
     runs-on: ubuntu-20.04
-
+    needs: [ upload-assets ]
     steps:
-      - name: Publish ${{ github.event.inputs.schema }} to S3 action
+      - name: Publish assets to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
@@ -39,11 +30,11 @@ jobs:
           AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
-          tag: ${{env.TAG}}
-          app_name: "td-agent-bit"
+          tag: ${{env.VERSION}}
+          app_name: "fluent-bit"
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/${{ github.event.inputs.schema }}.yml"
+          schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/fb-linux.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/.github/workflows/prerelease_linux_staged_publish.yml
+++ b/.github/workflows/prerelease_linux_staged_publish.yml
@@ -24,6 +24,7 @@ env:
   AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
   AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
   AWS_REGION: "us-east-1"
+  FB_PACKAGE_NAME: ${{ startsWith(github.event.release.tag_name, "1") && "td-agent-bit" || "fluent-bit" }}
 
 jobs:
   publishing-to-s3-linux:
@@ -40,7 +41,7 @@ jobs:
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
           tag: ${{env.TAG}}
-          app_name: "fluent-bit"
+          app_name: ${{env.FB_PACKAGE_NAME}}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/${{ github.event.inputs.schema }}.yml"

--- a/.github/workflows/prerelease_linux_staged_publish.yml
+++ b/.github/workflows/prerelease_linux_staged_publish.yml
@@ -1,13 +1,13 @@
-name: Staged release publish for Linux
+name: Staged pre-release publish for Linux
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release'
+        description: 'Tag to pre-release'
         required: true
       schema:
-        description: 'Schema to be released'
+        description: 'Schema to be pre-released'
         required: true
         options:
           - fb-amazonlinux
@@ -21,26 +21,26 @@ env:
   GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-  AWS_S3_BUCKET_NAME: "nr-downloads-main"
-  AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
+  AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
+  AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
   AWS_REGION: "us-east-1"
 
 jobs:
   publishing-to-s3-linux:
-    name: Publish linux artifacts into s3 production bucket
+    name: Publish linux artifacts into s3 staging bucket
     runs-on: ubuntu-20.04
 
     steps:
       - name: Publish ${{ github.event.inputs.schema }} to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_PRODUCTION }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
           tag: ${{env.TAG}}
-          app_name: "td-agent-bit"
+          app_name: "fluent-bit"
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/${{ github.event.inputs.schema }}.yml"
@@ -48,7 +48,7 @@ jobs:
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
           aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-          access_point_host: "production"
+          access_point_host: "staging"
           run_id: ${{ github.run_id }}
           aws_region: ${{ env.AWS_REGION }}
           aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -15,6 +15,7 @@ env:
   AWS_S3_BUCKET_NAME: "nr-downloads-main"
   AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
   AWS_REGION: "us-east-1"
+  FB_PACKAGE_NAME: ${{ startsWith(github.event.release.tag_name, "1") && "td-agent-bit" || "fluent-bit" }}
 
 jobs:
   publishing-to-s3:
@@ -31,7 +32,7 @@ jobs:
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
         with:
           tag: ${{env.TAG}}
-          app_name: "fluent-bit"
+          app_name: ${{env.FB_PACKAGE_NAME}}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/fb-linux.yml"

--- a/.github/workflows/release_linux_staged_publish.yml
+++ b/.github/workflows/release_linux_staged_publish.yml
@@ -24,6 +24,7 @@ env:
   AWS_S3_BUCKET_NAME: "nr-downloads-main"
   AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
   AWS_REGION: "us-east-1"
+  FB_PACKAGE_NAME: ${{ startsWith(github.event.release.tag_name, "1") && "td-agent-bit" || "fluent-bit" }}
 
 jobs:
   publishing-to-s3-linux:
@@ -40,7 +41,7 @@ jobs:
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
         with:
           tag: ${{env.TAG}}
-          app_name: "fluent-bit"
+          app_name: ${{env.FB_PACKAGE_NAME}}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/${{ github.event.inputs.schema }}.yml"

--- a/.github/workflows/release_linux_staged_publish.yml
+++ b/.github/workflows/release_linux_staged_publish.yml
@@ -1,14 +1,23 @@
-name: Release for Linux pipeline
+name: Staged release publish for Linux
 
 on:
-  release:
-    types:
-      - released
-    tags:
-      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+      schema:
+        description: 'Schema to be released'
+        required: true
+        options:
+          - fb-amazonlinux
+          - fb-centos
+          - fb-debian
+          - fb-sles
+          - fb-ubuntu
 
 env:
-  TAG: ${{ github.event.release.tag_name }}
+  TAG: ${{ github.event.inputs.tag }}
   GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
   GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
@@ -17,12 +26,12 @@ env:
   AWS_REGION: "us-east-1"
 
 jobs:
-  publishing-to-s3:
-    name: Publish linux artifacts into s3 test bucket
+  publishing-to-s3-linux:
+    name: Publish linux artifacts into s3 production bucket
     runs-on: ubuntu-20.04
 
     steps:
-      - name: Publish assets to S3 action
+      - name: Publish ${{ github.event.inputs.schema }} to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
@@ -34,7 +43,7 @@ jobs:
           app_name: "fluent-bit"
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
-          schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/fb-linux.yml"
+          schema_url: "https://raw.githubusercontent.com/newrelic/fluent-bit-package/main/schemas/${{ github.event.inputs.schema }}.yml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}


### PR DESCRIPTION
The target of this Pull Request is to separate the build of packages from the publishing to New Relic repository and update td-agent-bit packages to fluent-bit packages.

Fluent Bit has deprecated the td-agent-bit "flavor" on 2.0, and we need to support fluent-bit instead.

For that, we need that to be able to extract generated packages and test them before publishing to S3.

So this PR:

- Use fluent-bit instead td-agent-bit if release tag doesn't start with "1" that means... version is > 1.
- Remove the publishing from the prerelease workflow
- Add a new prerelease publish workflow that should be manually triggered