### PR TITLE
Remove AL2022 for arm64 as they're no packages for 2.0.8

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ jobs:
           - { arch: x86_64, distro: amazonlinux, version: 2, available-flavors: [td-agent-bit, fluent-bit] }
           - { arch: aarch64, distro: amazonlinux, version: 2, available-flavors: [td-agent-bit, fluent-bit] }
           - { arch: x86_64, distro: amazonlinux, version: 2022, available-flavors: [fluent-bit] }
-          - { arch: aarch64, distro: amazonlinux, version: 2022, available-flavors: [fluent-bit] }
+          # - { arch: aarch64, distro: amazonlinux, version: 2022, available-flavors: [fluent-bit] }
           - { arch: x86_64, distro: centos, version: 7, available-flavors: [td-agent-bit, fluent-bit] }
           - { arch: aarch64, distro: centos, version: 7, available-flavors: [td-agent-bit, fluent-bit] }
           - { arch: x86_64, distro: centos, version: 8, available-flavors: [td-agent-bit, fluent-bit] }


### PR DESCRIPTION
Amazon Linux 2022 has no package for Fluent Bit 2.0.8 only 2.0.4