### PR TITLE
Add sign workflow

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,50 @@
+name: Sign deb or rpm asset package
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to get / upload the package'
+        required: true
+      package:
+        description: 'Package file to sign'
+        required: true
+      regex:
+        description: 'Regex file name'
+        type: boolean
+        default: false
+        required: true
+
+env:
+  GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
+  GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+  GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+  VERSION: ${{ github.event.inputs.tag }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  sign_asset:
+    name: Sign asset
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Create packages folder
+        run: mkdir packages
+
+      - name: Fetch Github Release Asset
+        uses: dsaltares/fetch-gh-release-asset@1.1.0
+        with:
+          file: ${{ github.event.inputs.package }}
+          regex: ${{ github.event.inputs.regex == 'true' }}
+          version: tags/${{ github.event.inputs.tag }}
+          target: packages/${{ github.event.inputs.package }}
+
+      - name: Sign package
+        run: |
+          sudo apt-get install -y debsigs
+          bash ./scripts/sign.sh
+
+      - name: Upload signed asset
+        run: bash ./scripts/upload_assets_gh.sh


### PR DESCRIPTION
We need to manually build some packages (SLES) but we don't want to sign them manually as well.

This workflow allows us to download the packages from the assets of a release/pre-release, sign them and re-upload them.