### PR TITLE
Prerelease should not depend on upload-assets

### DIFF
--- a/.github/workflows/prerelease_linux_publish.yml
+++ b/.github/workflows/prerelease_linux_publish.yml
@@ -21,7 +21,7 @@ jobs:
   publishing-to-s3:
     name: Publish linux artifacts into s3 test bucket
     runs-on: ubuntu-20.04
-    needs: [ upload-assets ]
+    
     steps:
       - name: Publish assets to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3

--- a/.github/workflows/prerelease_linux_publish.yml
+++ b/.github/workflows/prerelease_linux_publish.yml
@@ -21,17 +21,18 @@ jobs:
   publishing-to-s3:
     name: Publish linux artifacts into s3 test bucket
     runs-on: ubuntu-20.04
-    
+
     steps:
       - name: Publish assets to S3 action
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
+          TAG: ${{ github.event.inputs.tag }}
           AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
           AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
           AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
-          tag: ${{env.VERSION}}
+          tag: ${{env.TAG}}
           app_name: ${{env.FB_PACKAGE_NAME}}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"


### PR DESCRIPTION
We split the prerelease process recently to be able to test packages before upload them to the repository and we left a dependency on a step that doesn't exist for the pre-release publishing workflow.

This PR removes that dependency.