### PR TITLE
Implement package downloading, repackaging and publishing to pre-release (Windows and Linux (non-SuSe))

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,10 @@ concurrency: pr-workflow-${{ github.event.pull_request.number }}
 env:
   GH_TOKEN: ${{ github.token }}
   PRE_RELEASE_NAME: tmp-pr-${{ github.event.pull_request.number }}
+  # Used to re-sign Linux artifacts
+  GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
+  GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+  GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
 
 jobs:
   # This is a workaround required to pass environment variables to the run_e2e_tests workflow
@@ -24,7 +28,93 @@ jobs:
         run: |
           echo "PRE_RELEASE_NAME=$PRE_RELEASE_NAME" >> $GITHUB_OUTPUT
 
-  build:
+  # Generates strategy matrices that can be used by other jobs to run the build or testing of all supported packages
+  prepare_matrices:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # Linux and Windows matrices are not used at the moment. Leaving them here as an example as we'll need to deal
+      # with separate matrices when building the SuSe packages.
+      linux_matrix: ${{ steps.set-matrix.outputs.linux_matrix }}
+      windows_matrix: ${{ steps.set-matrix.outputs.windows_matrix }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: | 
+          cd versions
+          npm install
+
+      - name: Compute matrix
+        id: set-matrix
+        run: |
+          cd versions
+          # Compute whole matrix
+          matrix=$( node strategyMatrix.js )
+          
+          # Compute matrix per OS type (leaving it for reference for when implementing SuSe)
+          linux_matrix=$( echo $matrix | jq 'map(select(.osDistro != "windows-server"))' -c )
+          windows_matrix=$( echo $matrix | jq 'map(select(.osDistro == "windows-server"))' -c )
+          
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "linux_matrix=$linux_matrix" >> "$GITHUB_OUTPUT"
+          echo "windows_matrix=$windows_matrix" >> "$GITHUB_OUTPUT"
+
+  # Downloads all Fluent Bit packages that are officially supported, preferably from the New Relic Infrastructure Agent
+  # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
+  # If these are not available, they are downloaded from the official Fluent Bit repository and repackaged to be used by the NRIA.
+  download_official_packages:
+    needs: [prepare_matrices]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{fromJson(needs.prepare_matrices.outputs.matrix)}}
+    name: ${{ matrix.osDistro }}-${{ matrix.osVersion }}-${{ matrix.arch }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Attempt downloading package from New Relic repository
+        id: download_package_from_nr
+        run: |
+          mkdir -p packages
+          if wget --directory-prefix=packages "${{ matrix.nrPackageUrl }}"; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download, rename and resign Linux package
+        if: ${{ steps.download_package_from_nr.outputs.result == 'failure' && matrix.osDistro != 'windows-server' }}
+        run: |
+          curl ${{ matrix.packageUrl }} -o packages/${{ matrix.targetPackageName }}
+          sudo apt-get install -y debsigs
+          bash ./scripts/sign.sh
+
+      - name: Download and re-zip Windows package
+        if: ${{ steps.download_package_from_nr.outputs.result == 'failure' && matrix.osDistro == 'windows-server' }}
+        run: |
+          wget ${{ matrix.packageUrl }}
+          unzip fluent-bit-${{ matrix.fbVersion }}-${{ matrix.arch }}.zip
+          zip -r -j packages/${{ matrix.targetPackageName }} \
+               fluent-bit-${{ matrix.fbVersion }}-${{ matrix.arch }}/bin/fluent-bit.exe \
+               fluent-bit-${{ matrix.fbVersion }}-${{ matrix.arch }}/bin/fluent-bit.dll
+
+        # gh release upload can have issues if multiple jobs attempt uploading the same file concurrently (it can happen
+        # for those distros using the same package, such as Windows). To avoid this, we first push all the files to a
+        # shared filesystem and let the "prepare_prerelease" step below upload them later, sequentially. This GH action
+        # ensures that if two jobs attempt pushing the same file, they get overwritten (last one prevails).
+      - uses: actions/upload-artifact@v2
+        with:
+          # Artifacts are pushed to *shared network folders* that have this name and that contain
+          # the artifact inside of them. Example: fluent-bit-2.1.8-386.exe/fluent-bit-2.1.8-386.exe
+          name: ${{ matrix.targetPackageName }}
+          path: packages/${{ matrix.targetPackageName }}
+
+  # Re-creates the GH prerelease on each commit and pushes all Fluent Bit packages there
+  prepare_prerelease:
+    needs: [ download_official_packages ]
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
 
@@ -32,34 +122,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Prepare pre-release
-        run: |
+      - name: (Re)create pre-release
+        run: | 
           pre_release_exists=$(gh release view $PRE_RELEASE_NAME &>/dev/null && echo "true" || echo "false")
-
           if [[ $pre_release_exists == "true" ]]; then
-            echo "Clearing files in pre-release $PRE_RELEASE_NAME"
-
-            packages=$(gh release view $PRE_RELEASE_NAME --json assets -q ".assets[].name")
-            for package in $packages; do
-              echo "  Deleting: $package"
-              gh release delete-asset $PRE_RELEASE_NAME "$package" -y
-            done
-          else
-            pre_release_tag=$PRE_RELEASE_NAME
-            pre_release_title="Temporary release to build and test artifacts from PR#${{ github.event.pull_request.number }}"
-            pre_release_notes="Created by PR: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
-
-            echo "Creating pre-release: $pre_release_tag"
-            gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes"
+            gh release delete ${{ env.PRE_RELEASE_NAME }} -y --cleanup-tag
           fi
+          
+          pre_release_tag=$PRE_RELEASE_NAME
+          pre_release_title="Temporary release to build and test artifacts from PR#${{ github.event.pull_request.number }}"
+          pre_release_notes="Created by PR: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
 
-      - name: Compiles Binaries and Uploads to Pre-release
-        run: |
-          # TODO
-          echo "TODO: Stubbed step"
+          echo "Creating pre-release: $pre_release_tag"
+          gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes"
 
+      - name: Download all artifacts from shared filesystem
+        uses: actions/download-artifact@v3
+        with:
+          path: packages
+
+      - name: Push all artifacts to pre-release
+        run:
+          # To understand the need for /*/*, see comment in "upload artifacts" step above
+          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/*
+
+  # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:
-    needs: [envSetup, build]
+    needs: [ envSetup, prepare_prerelease]
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       gh_release_name: ${{ needs.envSetup.outputs.PRE_RELEASE_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Local development tools/files
 .idea
+versions/node_modules

--- a/versions/amazonlinux_2.yml
+++ b/versions/amazonlinux_2.yml
@@ -1,0 +1,7 @@
+osDistro: amazonlinux
+osVersion: 2
+packages:
+  - arch: x86_64
+    ami: ami-0dfcb1ef8550277af
+  - arch: aarch64
+    ami: ami-0cd7323ab3e63805f

--- a/versions/amazonlinux_2022.yml
+++ b/versions/amazonlinux_2022.yml
@@ -1,0 +1,5 @@
+osDistro: amazonlinux
+osVersion: 2022
+packages:
+  - arch: x86_64
+    ami: ami-0ae4f98256391dad0

--- a/versions/centos_7.yml
+++ b/versions/centos_7.yml
@@ -1,0 +1,8 @@
+osDistro: centos
+osVersion: 7
+ec2User: centos
+packages:
+  - arch: x86_64
+    ami: ami-02358d9f5245918a3
+  - arch: aarch64
+    ami: ami-0144a5a84f5699847

--- a/versions/centos_8.yml
+++ b/versions/centos_8.yml
@@ -1,0 +1,8 @@
+osDistro: centos
+osVersion: 8
+ec2User: centos
+packages:
+  - arch: x86_64
+    ami: ami-0c07df890a618c98a
+  - arch: aarch64
+    ami: ami-09243ba0df36156d9

--- a/versions/centos_9.yml
+++ b/versions/centos_9.yml
@@ -1,0 +1,8 @@
+osDistro: centos
+osVersion: 9
+ec2User: centos
+packages:
+  - arch: x86_64
+    ami: ami-08c92aec9ccf0e1e9
+  - arch: aarch64
+    ami: ami-0c92309a18dff3e71

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,0 +1,18 @@
+fbVersion: 2.0.8
+ec2User: ec2-user
+
+#  This file, together with each distro file are processed and merged incrementally to
+#  build all the information required to download and test each package. Each package ends
+#  up having the following information fields which are later accessed by the GH workflows:
+#
+#  {
+#    "fbVersion": "2.0.8",
+#    "ec2User": "admin",
+#    "osDistro": "debian",
+#    "osVersion": "bookworm",
+#    "arch": "amd64",
+#    "ami": "ami-08ca7cb88210133e5",
+#    "packageUrl": "https://packages.fluentbit.io/debian/bookworm/fluent-bit_2.1.0_amd64.deb",
+#    "targetPackageName": "fluent-bit_2.1.0_debian-bookworm_amd64.deb",
+#    "nrPackageUrl": "https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit/fluent-bit_2.0.8_debian-bookworm_amd64.deb"
+#  }

--- a/versions/debian_10_buster.yml
+++ b/versions/debian_10_buster.yml
@@ -1,0 +1,8 @@
+osDistro: debian
+osVersion: buster
+ec2User: admin
+packages:
+  - arch: amd64
+    ami: ami-07d02ee1eeb0c996c
+  - arch: arm64
+    ami: ami-08b2293fdd2deba2a

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -1,0 +1,8 @@
+osDistro: debian
+osVersion: bullseye
+ec2User: admin
+packages:
+  - arch: amd64
+    ami: ami-052465340e6b59fc0
+  - arch: arm64
+    ami: ami-0ffd2fd6f1a81e491

--- a/versions/debian_12_bookworm.yml
+++ b/versions/debian_12_bookworm.yml
@@ -1,0 +1,8 @@
+osDistro: debian
+osVersion: bookworm
+ec2User: admin
+packages:
+  - arch: amd64
+    ami: ami-08ca7cb88210133e5
+  - arch: arm64
+    ami: ami-0efa233eb46a48f36

--- a/versions/package-lock.json
+++ b/versions/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "versions",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "read-yaml-file": "^2.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/read-yaml-file": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
+      "integrity": "sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==",
+      "dependencies": {
+        "js-yaml": "^4.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "read-yaml-file": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
+      "integrity": "sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==",
+      "requires": {
+        "js-yaml": "^4.0.0",
+        "strip-bom": "^4.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+    }
+  }
+}

--- a/versions/package.json
+++ b/versions/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "read-yaml-file": "^2.1.0"
+  }
+}

--- a/versions/strategyMatrix.js
+++ b/versions/strategyMatrix.js
@@ -1,0 +1,146 @@
+const fs = require('fs')
+const readYamlFile = require('read-yaml-file')
+
+/*
+This file builds the strategy matrix to be used in the pull_request.yml. For each supported package to be built/tested,
+it builds a JSON object by merging all the fields in the following order (taking centos_9.yml as an example):
+
+  1. Values in "common.yml".
+  2. Values in the root of "centos_9.yml", excluding the "packages" array attribute.
+  3. Values in "centos_9.yml" from each element of the "packages" array attribute.
+
+Each of the previous steps can overwrite any attribute defined in the previous level. For example, imagine
+the following values:
+
+    ---common.yml
+    fbVersion: 2.0.8
+    ec2User: ec2-user
+
+    ---centos_9.yml
+    osDistro: centos
+    osVersion: 9
+    ec2User: centos      // Overrides value from "common.yml
+    fbVersion: 2.0.7     // Overrides value from "common.yml"
+    packages:
+      - arch: x86_64
+        ami: ami-08c92aec9ccf0e1e9
+      - arch: aarch64
+        ami: ami-0c92309a18dff3e71
+        fbVersion: 2.0.6 // Overrides value from root of "centos_9.yml"
+
+This results in the following JSON objects in the resulting strategy matrix (represented in JSON here):
+
+{
+    "fbVersion": "2.0.7",
+    "ec2User": "centos",
+    "osDistro": "centos",
+    "osVersion": 9,
+    "arch": "x86_64",
+    "ami": "ami-08c92aec9ccf0e1e9",
+    "packageUrl": "https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-2.0.7-1.x86_64.rpm",
+    "targetPackageName": "fluent-bit-2.0.7-1.centos-9.x86_64.rpm",
+    "nrPackageUrl": "https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/el/9/x86_64/fluent-bit-2.0.7-1.centos-9.x86_64.rpm"
+  },
+  {
+    "fbVersion": "2.0.6",
+    "ec2User": "centos",
+    "osDistro": "centos",
+    "osVersion": 9,
+    "arch": "aarch64",
+    "ami": "ami-0c92309a18dff3e71",
+    "packageUrl": "https://packages.fluentbit.io/centos/9/aarch64/fluent-bit-2.0.6-1.aarch64.rpm",
+    "targetPackageName": "fluent-bit-2.0.6-1.centos-9.arm64.rpm",
+    "nrPackageUrl": "https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/el/9/aarch64/fluent-bit-2.0.6-1.centos-9.arm64.rpm"
+  }
+
+This script file takes care of computing the following attributes for each supported package:
+
+    - "packageUrl": Official Fluent Bit package for this distribution in the official Fluent Bit repository.
+    - "targetPackageName": File name for the package to be stored in the New Relic Infrastructure Agent repository (Linux
+       packages) or Logging S3 bucket (Windows packages)
+    - "nrPackageUrl": Re-packaged Fluent Bit package for this distribution in the New Relic Infrastructure Agent repository
+       (Linux packages) or Logging S3 bucket (Windows packages)
+ */
+
+const DEB_DISTROS = ['debian', 'ubuntu']
+const WINDOWS_DISTRO = 'windows-server'
+
+const DEB_PACKAGE_DETAILS = ({osDistro, osVersion, fbVersion, arch}) => ({
+    packageUrl: `https://packages.fluentbit.io/${osDistro}/${osVersion}/fluent-bit_${fbVersion}_${arch}.deb`,
+    targetPackageName: `fluent-bit_${fbVersion}_${osDistro}-${osVersion}_${arch}.deb`,
+    nrPackageUrl: `https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit/fluent-bit_${fbVersion}_${osDistro}-${osVersion}_${arch}.deb`
+})
+
+const RPM_TARGET_ARCH_REMAP = {'aarch64': 'arm64', 'x86_64': 'x86_64'}
+const RPM_OS_FAMILY_REMAP = {'amazonlinux': 'amazonlinux', 'centos': 'el'}
+const RPM_PACKAGE_DETAILS = ({osDistro, osVersion, fbVersion, arch}) => ({
+    packageUrl: `https://packages.fluentbit.io/${osDistro}/${osVersion}/${arch}/fluent-bit-${fbVersion}-1.${arch}.rpm`,
+    targetPackageName: `fluent-bit-${fbVersion}-1.${osDistro}-${osVersion}.${RPM_TARGET_ARCH_REMAP[arch]}.rpm`,
+    nrPackageUrl: `https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/${RPM_OS_FAMILY_REMAP[osDistro]}/${osVersion}/${arch}/fluent-bit-${fbVersion}-1.${osDistro}-${osVersion}.${RPM_TARGET_ARCH_REMAP[arch]}.rpm`
+})
+
+const WINDOWS_TARGET_ARCH_REMAP = {'win32': '386', 'win64': 'amd64'}
+const WINDOWS_PACKAGE_DETAILS = ({fbVersion, arch}) => ({
+    packageUrl: `http://fluentbit.io/releases/${getMajorMinorVersion(fbVersion)}/fluent-bit-${fbVersion}-${arch}.zip`,
+    targetPackageName: `fb-windows-${fbVersion}-${WINDOWS_TARGET_ARCH_REMAP[arch]}.zip`
+    // TODO: add URL to Logging's S3 bucket holding Windows packages here
+    // nrPackageUrl: 'url'
+})
+
+// Returns only the major and minor version of a string. If version is "2.1.7", this returns "2.1"
+const getMajorMinorVersion = (version) => (version.split('.').slice(0,2).join('.'))
+
+const addPackageDetails = (packageData) => {
+    const { osDistro } = packageData
+
+    let packageDetails
+    if (WINDOWS_DISTRO === osDistro) {
+        packageDetails = WINDOWS_PACKAGE_DETAILS(packageData)
+    }
+    else if (DEB_DISTROS.includes(osDistro)) {
+        packageDetails = DEB_PACKAGE_DETAILS(packageData)
+    }
+    else {
+        packageDetails = RPM_PACKAGE_DETAILS(packageData)
+    }
+
+    return {
+        ...packageData,
+        ...packageDetails
+    }
+}
+
+const readDistroPackages = async (distroFile) => {
+    const commonData = await readYamlFile('common.yml')
+    const { packages, ...commonDistroData} = await readYamlFile(distroFile)
+
+    return packages.map(packageData => ({
+        ...commonData,
+        ...commonDistroData,
+        ...packageData
+    }))
+}
+
+const listDistroFiles = () => {
+    try {
+        return fs.readdirSync('.').filter((filename) =>
+            (filename.endsWith('.yml') || filename.endsWith('.yaml')) && filename !== 'common.yml'
+        );
+    } catch (err) {
+        console.error('Error while reading distribution package files:', err);
+    }
+}
+
+const generateMatrix = async () => {
+    return (await Promise.all(listDistroFiles().map(readDistroPackages)))
+        .flat()
+        .map(addPackageDetails)
+}
+
+(async () => {
+    const matrix = await generateMatrix()
+    console.log(JSON.stringify(matrix))
+})();
+
+
+

--- a/versions/ubuntu_18_bionic.yml
+++ b/versions/ubuntu_18_bionic.yml
@@ -1,0 +1,8 @@
+osDistro: ubuntu
+osVersion: bionic
+ec2User: ubuntu
+packages:
+  - arch: amd64
+    ami: ami-0263e4deb427da90e
+  - arch: arm64
+    ami: ami-0a5ec5786500eaf19

--- a/versions/ubuntu_20_focal.yml
+++ b/versions/ubuntu_20_focal.yml
@@ -1,0 +1,8 @@
+osDistro: ubuntu
+osVersion: focal
+ec2User: ubuntu
+packages:
+  - arch: amd64
+    ami: ami-0c4f7023847b90238
+  - arch: arm64
+    ami: ami-0d70a59d7191a8079

--- a/versions/ubuntu_22_jammy.yml
+++ b/versions/ubuntu_22_jammy.yml
@@ -1,0 +1,8 @@
+osDistro: ubuntu
+osVersion: jammy
+ec2User: ubuntu
+packages:
+  - arch: amd64
+    ami: ami-00874d747dde814fa
+  - arch: arm64
+    ami: ami-0a84a722790d914a9

--- a/versions/windows-server-2019.yml
+++ b/versions/windows-server-2019.yml
@@ -1,0 +1,8 @@
+osDistro: windows-server
+osVersion: 2019
+ec2User: Administrator
+packages:
+  - arch: win64
+    ami: ami-024614f01f42eeb66
+  - arch: win32
+    ami: ami-024614f01f42eeb66

--- a/versions/windows-server-2022.yml
+++ b/versions/windows-server-2022.yml
@@ -1,0 +1,8 @@
+osDistro: windows-server
+osVersion: 2022
+ec2User: Administrator
+packages:
+  - arch: win64
+    ami: ami-0c2b0d3fb02824d92
+  - arch: win32
+    ami: ami-0c2b0d3fb02824d92


### PR DESCRIPTION
In this PR, we implement the logic in the `pull_request.yml` workflow to download the Fluent Bit packages either from the New Relic repositories (Infrastructure Agent repository for Linux packages, Logging S3 bucket for Windows ones) preferably, and fall back to downloading them from Fluent Bit's official repository if not available there (newer versions).

We have introduced what package version and architecture to be downloaded for each distro as YML files in the `versions` directory. Each package details are built incrementally by merging the details in `common.yml`, `<distro.yml>` and the `packages` in `<distro>.yml`. See comment in `versions/strategyMatrix.js` for more details.

The `strategyMatrix.js` script is used to read these YML files and generate a strategy matrix that is later read dynamically from the GH workflow.