### PR TITLE
Spin up and down suse ec2 instances

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,11 +32,7 @@ jobs:
   prepare_matrices:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrices.outputs.matrix }}
-      # Linux and Windows matrices are not used at the moment. Leaving them here as an example as we'll need to deal
-      # with separate matrices when building the SuSe packages.
-      linux_matrix: ${{ steps.set-matrices.outputs.linux_matrix }}
-      windows_matrix: ${{ steps.set-matrices.outputs.windows_matrix }}
+      linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
     steps:
       - uses: actions/checkout@v2
 
@@ -50,9 +46,7 @@ jobs:
         run: |
           make versions
           
-          echo "matrix=$( cat versions/strategyMatrix.json )" >> "$GITHUB_OUTPUT"
-          echo "linux_matrix=$( cat versions/linuxMatrix.json )" >> "$GITHUB_OUTPUT"
-          echo "windows_matrix=$( cat versions/windowsMatrix.json )" >> "$GITHUB_OUTPUT"
+          echo "linux_and_windows_matrix=$( cat versions/linuxAndWindowsMatrix.json )" >> "$GITHUB_OUTPUT"
 
   # Downloads all Fluent Bit packages that are officially supported, preferably from the New Relic Infrastructure Agent
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
@@ -63,7 +57,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        include: ${{fromJson(needs.prepare_matrices.outputs.matrix)}}
+        include: ${{ fromJson(needs.prepare_matrices.outputs.linux_and_windows_matrix) }}
     name: ${{ matrix.osDistro }}-${{ matrix.osVersion }}-${{ matrix.arch }}
     steps:
       - name: Check out repository
@@ -130,9 +124,9 @@ jobs:
 
   # Re-creates the GH prerelease on each commit and pushes all Fluent Bit packages there
   prepare_prerelease:
+    if: github.event.action != 'closed'
     needs: [ download_official_packages ]
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
 
     steps:
       - name: Checkout code

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -9,6 +9,10 @@ ifndef PR_NUMBER
 	$(error PR_NUMBER is undefined)
 endif
 
+.PHONY: generateMatrices
+generateMatrices:
+	$(MAKE) -C ../versions generateMatrices
+
 # Creates Terraform backend file pointing to a S3 state file
 .PHONY: terraform/backend
 terraform/backend: checks
@@ -17,19 +21,24 @@ terraform/backend: checks
 	fi
 	@echo "Creating Terraform state file in ./${TERRAFORM_PROJECT}/terraform.backend.tf from template in ./${TERRAFORM_PROJECT}/terraform.backend.tf.dist"
 	@sed "s/PR_NUMBER/${PR_NUMBER}/g" "./${TERRAFORM_PROJECT}/terraform.backend.tf.dist" > "./${TERRAFORM_PROJECT}/terraform.backend.tf"
-	cat "./${TERRAFORM_PROJECT}/terraform.backend.tf"
+
+# Exports environment variables that are accessed by the launched Terraform project
+.PHONY: terraform/vars
+terraform/vars:
+	echo "pr_number = \"${PR_NUMBER}\"" >> "./${TERRAFORM_PROJECT}/variables.tfvars"
 
 # Terraform-applies
 .PHONY: provision
-provision: terraform/backend
+provision: terraform/backend terraform/vars generateMatrices
 	@echo "Provisioning TERRAFORM_PROJECT=${TERRAFORM_PROJECT} from PR_NUMBER=${PR_NUMBER}"
-#	terraform -chdir=$(TERRAFORM_PROJECT) init -reconfigure && \
-#	terraform -chdir=$(TERRAFORM_PROJECT) apply -auto-approve
+	terraform -chdir=$(TERRAFORM_PROJECT) init -reconfigure && \
+	terraform -chdir=$(TERRAFORM_PROJECT) apply -auto-approve -var-file="variables.tfvars"
+	# terraform -chdir=$(TERRAFORM_PROJECT) plan -var-file="variables.tfvars"
 
 # Terraform-destroys
 .PHONY: clean
-clean: terraform/backend
-#	terraform -chdir=$(TERRAFORM_PROJECT) init -reconfigure && \
-#	terraform -chdir=$(TERRAFORM_PROJECT) destroy -auto-approve &&
+clean: terraform/backend terraform/vars generateMatrices
+	terraform -chdir=$(TERRAFORM_PROJECT) init -reconfigure && \
+	terraform -chdir=$(TERRAFORM_PROJECT) destroy -auto-approve -var-file="variables.tfvars"
 	@echo "Removing Terraform backend file $(TERRAFORM_PROJECT)/terraform.backend.tf"
 	@rm "$(TERRAFORM_PROJECT)/terraform.backend.tf"

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -1,0 +1,55 @@
+locals {
+  # Available fields in each element:
+  #  {
+  #    "fbVersion": "2.0.7",
+  #    "ec2User": "centos",
+  #    "osDistro": "centos",
+  #    "osVersion": 9,
+  #    "arch": "x86_64",
+  #    "ami": "ami-08c92aec9ccf0e1e9",
+  #    ...
+  #  }
+  instance_matrix = jsondecode(file(var.instance_matrix_file))
+
+  aws_vpc_subnet = "subnet-06240c469195932cf"
+  ec2_instances_security_group = "sg-0c4318be91bbe3cba"
+  ec2_instance_profile = "logging-e2e-testing-ec2-ssm-instance-profile"
+
+  # See: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent-status-and-restart.html
+  # TODO Verify for Ubuntu: it seems Ubuntu >18 uses snap, but verify if systemctl also starts SSM agent correctly
+  linux_user_data_boot_script_for_ssm = <<EOF
+#!/bin/bash
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+EOF
+  # TODO Test
+  windows_data_boot_script_for_ssm = <<EOF
+Start-Service AmazonSSMAgent
+EOF
+
+  # Default tags applied to all created resources
+  default_tags = {
+    product = "logging"
+    owning_team = "logging"
+    project = "fluent-bit-packaging-and-testing"
+  }
+}
+
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+
+  for_each = { for pkg in local.instance_matrix : "pr-${var.pr_number}-${pkg.osDistro}-${pkg.osVersion}-${pkg.arch}-fb-${pkg.fbVersion}-builder" => pkg }
+
+  name = each.key
+
+  ami                    = each.value.ami
+  instance_type          = "t3.small"
+  vpc_security_group_ids = [local.ec2_instances_security_group]
+  subnet_id              = local.aws_vpc_subnet
+
+  iam_instance_profile   = local.ec2_instance_profile
+
+  user_data = each.value.osDistro == "windows-server" ? local.windows_data_boot_script_for_ssm : local.linux_user_data_boot_script_for_ssm
+
+  tags = local.default_tags
+}

--- a/terraform/ec2-instances-creator/variables.tf
+++ b/terraform/ec2-instances-creator/variables.tf
@@ -1,0 +1,9 @@
+variable "instance_matrix_file" {
+  type = string
+  description = "File from where the instance matrix in JSON format will be loaded from."
+}
+
+variable "pr_number" {
+  type = string
+  description = "Pull request number"
+}

--- a/terraform/ec2-suse-builders/main.tf
+++ b/terraform/ec2-suse-builders/main.tf
@@ -1,0 +1,11 @@
+locals {
+  suse_matrix_path = "../../versions/slesMatrix.json"
+}
+
+
+module "suse-fb-builder-instances" {
+  source = "../ec2-instances-creator"
+
+  instance_matrix_file = local.suse_matrix_path
+  pr_number = var.pr_number
+}

--- a/terraform/ec2-suse-builders/terraform.backend.tf.dist
+++ b/terraform/ec2-suse-builders/terraform.backend.tf.dist
@@ -3,8 +3,9 @@
 #########################################
 terraform {
   backend "s3" {
-    bucket = "logging-e2e-testing-tf"
-    key    = "suse-builders-pr-PR_NUMBER"
-    region = "us-east-2"
+    encrypt = true
+    bucket  = "logging-e2e-testing-tf"
+    key     = "suse-builders-pr-PR_NUMBER"
+    region  = "us-east-2"
   }
 }

--- a/terraform/ec2-suse-builders/variables.tf
+++ b/terraform/ec2-suse-builders/variables.tf
@@ -1,0 +1,4 @@
+variable "pr_number" {
+  type = string
+  description = "Pull request number"
+}

--- a/versions/Makefile
+++ b/versions/Makefile
@@ -4,5 +4,5 @@
 generateMatrices:
 	pip3 install -r requirements.txt
 	python3 strategyMatrix.py > strategyMatrix.json
-	cat strategyMatrix.json | jq 'map(select(.osDistro != "windows-server"))' -c > linuxMatrix.json
-	cat strategyMatrix.json | jq 'map(select(.osDistro == "windows-server"))' -c > windowsMatrix.json
+	cat strategyMatrix.json | jq 'map(select(.osDistro == "sles"))' -c > slesMatrix.json
+	cat strategyMatrix.json | jq 'map(select(.osDistro != "sles"))' -c > linuxAndWindowsMatrix.json

--- a/versions/sles_12.1.yml
+++ b/versions/sles_12.1.yml
@@ -1,0 +1,6 @@
+osDistro: sles
+osVersion: 12.1
+packages:
+  - arch: x86_64
+    # It suses the one from SLES 12.3 since there is none available for 12.1
+    ami: ami-03ce00a6a270d98ef

--- a/versions/sles_12.2.yml
+++ b/versions/sles_12.2.yml
@@ -1,0 +1,6 @@
+osDistro: sles
+osVersion: 12.2
+packages:
+  - arch: x86_64
+    # It suses the one from SLES 12.3 since there is none available for 12.2
+    ami: ami-03ce00a6a270d98ef

--- a/versions/sles_12.3.yml
+++ b/versions/sles_12.3.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 12.3
+packages:
+  - arch: x86_64
+    ami: ami-03ce00a6a270d98ef

--- a/versions/sles_12.4.yml
+++ b/versions/sles_12.4.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 12.4
+packages:
+  - arch: x86_64
+    ami: ami-07c710f0c3b92fd0c

--- a/versions/sles_12.5.yml
+++ b/versions/sles_12.5.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 12.5
+packages:
+  - arch: x86_64
+    ami: ami-06dec9fcc0c723281

--- a/versions/sles_15.1.yml
+++ b/versions/sles_15.1.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 15.1
+packages:
+  - arch: x86_64
+    ami: ami-06728afdd143525ba

--- a/versions/sles_15.2.yml
+++ b/versions/sles_15.2.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 15.2
+packages:
+  - arch: x86_64
+    ami: ami-0b53003810daecb6d

--- a/versions/sles_15.3.yml
+++ b/versions/sles_15.3.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 15.3
+packages:
+  - arch: x86_64
+    ami: ami-0d80ccb98990ccf53

--- a/versions/sles_15.4.yml
+++ b/versions/sles_15.4.yml
@@ -1,0 +1,5 @@
+osDistro: sles
+osVersion: 15.4
+packages:
+  - arch: x86_64
+    ami: ami-04bec2ee7152c1c8c

--- a/versions/strategyMatrix.py
+++ b/versions/strategyMatrix.py
@@ -64,6 +64,7 @@ This script file takes care of computing the following attributes for each suppo
 """
 
 DEB_DISTROS = ['debian', 'ubuntu']
+RPM_DISTROS = ['amazonlinux', 'centos']
 WINDOWS_DISTRO = 'windows-server'
 
 def deb_package_details(pkg):
@@ -82,6 +83,14 @@ def rpm_package_details(pkg):
         'targetPackageName': f"fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}-{pkg['osVersion']}.{rpm_target_arch_remap[pkg['arch']]}.rpm",
         'nrPackageUrl': 
 f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/{rpm_os_family_remap[pkg['osDistro']]}/{pkg['osVersion']}/{pkg['arch']}/fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}-{pkg['osVersion']}.{rpm_target_arch_remap[pkg['arch']]}.rpm"
+    }
+
+def sles_package_details(pkg):
+    return {
+        # SLES packages are not officially available in Fluent Bit repos (we compile them ourselves), so no 'packageUrl' is available for them.
+        'targetPackageName': f"fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}{pkg['osVersion']}.{pkg['arch']}.rpm",
+        'nrPackageUrl':
+            f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/zypp/{pkg['osDistro']}/{pkg['osVersion']}/{pkg['arch']}/fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}{pkg['osVersion']}.{pkg['arch']}.rpm"
     }
 
 def windows_package_details(data):
@@ -104,8 +113,10 @@ def add_package_details(package_data):
         package_details = windows_package_details(package_data)
     elif os_distro in DEB_DISTROS:
         package_details = deb_package_details(package_data)
-    else:
+    elif os_distro in RPM_DISTROS:
         package_details = rpm_package_details(package_data)
+    else:
+        package_details = sles_package_details(package_data)
 
     return {**package_data, **package_details}
 


### PR DESCRIPTION
This PR performs the necessary changes to create and destroy the SUSE builder VMs that will compile the Fluent Bit packages. I have provided some comments below to help with the review process, but these are the main changes in this PR:
- Added the `versions/sles_<VERSION>.yml` files to include the SUSE versions in the `slesMatrix.json` strategy matrix. Adapted `versions/Makefile` and `versions/strategyMatrix.py` accordingly.
- Added a new Terraform project under `terraform` to create EC2 instances named `ec2-instances-creator`. This project creates the EC2 instances as indicated by the provided matrix file. It attaches them to the appropriate private subnet and security group, and provides them with the appropriate boot script so that the AWS SSM agent is started on boot.
- Added a new Terraform project under `terraform` to create the SUSE builder VMs, named `ec2-suse-builders`. This project simply re-uses the `ec2-instances-creator` module and passes the appropriate `suseMatrix.json` file to it.
- Modified `terraform/Makefile` to now run `terraform apply` and `terraform destroy`. It also takes care of generating the strategy matrix files and passing the appropriate variables to the Terraform project to be executed.