### PR TITLE
Be able to run tasks locally

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,20 @@
+# How to test make targets locally
+The "local" make target allows you to test any make target like you were executing it remotely in a Fargate task. Instead,
+though, it will execute it in a local Docker container using the same image used by the Fargate task and by mounting this
+repository (in its current status, locally) as a volume instead of pulling it from GitHub.
+
+This target accepts a single argument, named "target", which specifies what target needs to be executed inside the container,
+as well as its arguments. Note that **the PR_NUMBER environment variable does NOT need to be provided**. Instead, the "local"
+make target will set it up for you to the value `local-<YOUR_USERNAME>`.
+
+Example usage:
+```
+make local target="terraform TERRAFORM_PROJECT=ec2-suse-builders"
+```
+
+In the above example, this would create the SUSE builder VMs, and the corresponding Terraform state would be stored in
+the backend S3 bucket under the key `suse-builders-pr-local-<YOUR_USERNAME>`. To destroy the created resources, you'd need
+to then run:
+```
+make local target="terraform-clean TERRAFORM_PROJECT=ec2-suse-builders"
+```

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ FIND_PATH = . -mindepth 2 -not -path '*/\.*'
 SUBDIRS := $(patsubst ./%/Makefile,%,$(shell find $(FIND_PATH) -name Makefile))
 TARGETS := $(SUBDIRS)
 
-.PHONY: all $(TARGETS) clean $(addsuffix -clean,$(TARGETS)) help
+.PHONY: all $(TARGETS) clean $(addsuffix -clean,$(TARGETS)) help local
 
 $(TARGETS):
 	$(MAKE) -C $@
@@ -17,6 +17,15 @@ clean: $(addsuffix -clean,$(SUBDIRS))
 $(addsuffix -clean,$(TARGETS)):
 	$(MAKE) -C $(patsubst %-clean,%,$@) clean
 
+local:
+	docker run -it --platform=linux/amd64 -v $(shell pwd)/tools/local_testing_entrypoint.sh:/entrypoint.sh \
+		-v $(shell pwd):/srv/fluent-bit-package \
+		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+		-e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
+		-e AWS_DEFAULT_REGION=us-east-2 \
+		ghcr.io/newrelic/fargate-runner-action:latest \
+		$(target) PR_NUMBER=local-$(USER)
 
 help:
 	@echo "## Available targets:"

--- a/tools/local_testing_entrypoint.sh
+++ b/tools/local_testing_entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d "/srv/fluent-bit-package" ]; then
+    printf "Repository was not properly mounted. Mount it at /srv/fluent-bit-package\n" >&2
+    exit 1
+fi
+
+if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
+    printf "AWS_ACCESS_KEY_ID env variable is empty\n" >&2
+    exit 1
+fi
+
+if [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+    printf "AWS_SECRET_ACCESS_KEY env variable is empty\n" >&2
+    exit 1
+fi
+
+if [ -z "${AWS_SESSION_TOKEN}" ]; then
+    printf "AWS_SESSION_TOKEN env variable is empty\n" >&2
+    exit 1
+fi
+
+# To avoid running terraform apply/destroy on the volume, which would save the state locally
+cd /srv
+cp -R fluent-bit-package fluent-bit-package-copy
+cd fluent-bit-package-copy
+
+mkdir -p "${ANSIBLE_INVENTORY_FOLDER}"
+
+make "${@}"


### PR DESCRIPTION
This PR adds the "local" make target, which allows the developer to test any make target like it was executed remotely in a Fargate task. Instead, though, it will execute it in a local Docker container using the same image used by the Fargate task and by mounting this repository (in its current status, locally) as a volume instead of pulling it from GitHub.
