### PR TITLE
Provision SUSE instances and build Fluent Bit

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -107,6 +107,7 @@ jobs:
     secrets: inherit
 
   build_suse_packages:
+    needs: spin_up_suse
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "ansible/build-fb-suse PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Fetch package from GitHub pre-release
         run: |
           mkdir -p packages
-          gh release download tag --pattern ${{ matrix.targetPackageName }} --dir packages
+          gh release download ${{ env.PRE_RELEASE_NAME }} --pattern ${{ matrix.targetPackageName }} --dir packages
 
       - name: Sign package
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload signed asset
         run:
-          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*
+          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/* --clobber
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -107,13 +107,10 @@ jobs:
     secrets: inherit
 
   build_suse_packages:
-    needs: spin_up_suse
-    runs-on: ubuntu-latest
-
-    steps:
-      # This is where the real compilation will actually happen
-      - name: Checkout code
-        uses: actions/checkout@v3
+    uses: ./.github/workflows/run_task.yml
+    with:
+      container_make_target: "ansible/build-fb-suse PR_NUMBER=${{ github.event.pull_request.number }}"
+    secrets: inherit
 
   tear_down_suse:
     needs: build_suse_packages

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,14 +100,14 @@ jobs:
           name: ${{ matrix.targetPackageName }}
           path: packages/${{ matrix.targetPackageName }}
 
-  spin_up_suse:
-    uses: ./.github/workflows/run_task.yml
-    with:
-      container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
-    secrets: inherit
+#  spin_up_suse:
+#    uses: ./.github/workflows/run_task.yml
+#    with:
+#      container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
+#    secrets: inherit
 
   build_suse_packages:
-    needs: spin_up_suse
+    # needs: spin_up_suse
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "ansible/build-fb-suse PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pre_release_name: ${{ steps.set_vars.outputs.pre_release_name }}
+      sles_matrix: ${{ steps.set_vars.outputs.sles_matrix }}
       linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
     steps:
       - name: Checkout code
@@ -57,6 +58,7 @@ jobs:
         run: |
           make versions
           echo "linux_and_windows_matrix=$( cat versions/linuxAndWindowsMatrix.json )" >> "$GITHUB_OUTPUT"
+          echo "sles_matrix=$( cat versions/slesMatrix.json )" >> "$GITHUB_OUTPUT"
 
   # Downloads all Fluent Bit packages that are officially supported, preferably from the New Relic Infrastructure Agent
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
@@ -149,12 +151,29 @@ jobs:
   sign_suse_packages:
     needs: build_suse_packages
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJson(needs.setup_environment.outputs.sles_matrix) }}
+    name: ${{ matrix.osDistro }}-${{ matrix.osVersion }}-${{ matrix.arch }}
 
     steps:
-      - name: Sign STUB
-        run:
-          echo "TODO"
+      - name: Check out repository
+        uses: actions/checkout@v3
 
+      - name: Fetch package from GitHub pre-release
+        run:
+          mkdir -p packages
+          gh release download tag --pattern ${{ matrix.targetPackageName }} --dir packages
+
+      - name: Sign package
+        run: |
+          sudo apt-get install -y debsigs
+          bash ./scripts/sign.sh
+
+      - name: Upload signed asset
+        run:
+          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,14 +100,14 @@ jobs:
           name: ${{ matrix.targetPackageName }}
           path: packages/${{ matrix.targetPackageName }}
 
-#  spin_up_suse:
-#    uses: ./.github/workflows/run_task.yml
-#    with:
-#      container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
-#    secrets: inherit
+  spin_up_suse:
+    uses: ./.github/workflows/run_task.yml
+    with:
+      container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
+    secrets: inherit
 
   build_suse_packages:
-    # needs: spin_up_suse
+    needs: spin_up_suse
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "ansible/build-fb-suse PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -162,7 +162,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Fetch package from GitHub pre-release
-        run:
+        run: |
           mkdir -p packages
           gh release download tag --pattern ${{ matrix.targetPackageName }} --dir packages
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pre_release_name: ${{ steps.set_vars.outputs.pre_release_name }}
-      sles_matrix: ${{ steps.set_vars.outputs.sles_matrix }}
+      sles_matrix: ${{ steps.set-matrices.outputs.sles_matrix }}
       linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
     steps:
       - name: Checkout code

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
     name: ${{ matrix.osDistro }}-${{ matrix.osVersion }}-${{ matrix.arch }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Attempt downloading package from New Relic repository
         id: download_package_from_nr
@@ -123,10 +123,10 @@ jobs:
       - name: Push all artifacts to pre-release
         run:
           # To understand the need for /*/*, see comment in "upload artifacts" step above
-          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/*
+          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/* --repo newrelic/fluent-bit-package
 
   spin_up_suse:
-    needs: [setup_environment]
+    needs: setup_environment
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
@@ -147,14 +147,14 @@ jobs:
     secrets: inherit
 
   sign_suse_packages:
-    needs: [build_suse_packages]
+    needs: build_suse_packages
     runs-on: ubuntu-latest
 
     steps:
       - name: Sign STUB
         run:
           echo "TODO"
-        
+
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -123,7 +123,7 @@ jobs:
   # Re-creates the GH prerelease on each commit and pushes all Fluent Bit packages there
   prepare_prerelease:
     if: github.event.action != 'closed'
-    needs: [ download_official_packages ]
+    needs: [ download_official_packages, build_suse_packages ]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -149,7 +149,7 @@ jobs:
     secrets: inherit
 
   sign_suse_packages:
-    needs: build_suse_packages
+    needs: [setup_environment, build_suse_packages]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,26 +15,37 @@ env:
   GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
 
 jobs:
-  # This is a workaround required to pass environment variables to the run_e2e_tests workflow
-  # See: https://stackoverflow.com/a/73305536 and https://github.com/orgs/community/discussions/26671#discussioncomment-3252793
-  envSetup:
-    name: Setup dynamic environment variables
+  # Empties the GH pre-relase
+  # Generates strategy matrices that can be used by other jobs to run the build or testing of all supported packages
+  setup_environment:
     runs-on: ubuntu-latest
     outputs:
-      PRE_RELEASE_NAME: ${{ steps.set_vars.outputs.PRE_RELEASE_NAME }}
+      pre_release_name: ${{ steps.set_vars.outputs.pre_release_name }}
+      linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+        # This is a workaround required to pass environment variables to the run_e2e_tests workflow
+        # See: https://stackoverflow.com/a/73305536 and https://github.com/orgs/community/discussions/26671#discussioncomment-3252793
       - name: Make dynamically-generated env variables available to be passed down to reusable workflows
         id: set_vars
         run: |
-          echo "PRE_RELEASE_NAME=$PRE_RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "pre_release_name=$PRE_RELEASE_NAME" >> $GITHUB_OUTPUT
 
-  # Generates strategy matrices that can be used by other jobs to run the build or testing of all supported packages
-  prepare_matrices:
-    runs-on: ubuntu-latest
-    outputs:
-      linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
-    steps:
-      - uses: actions/checkout@v2
+      - name: (Re)create pre-release
+        run: |
+          pre_release_exists=$(gh release view $PRE_RELEASE_NAME &>/dev/null && echo "true" || echo "false")
+          if [[ $pre_release_exists == "true" ]]; then
+            gh release delete ${{ env.PRE_RELEASE_NAME }} -y --cleanup-tag
+          fi
+
+          pre_release_tag=$PRE_RELEASE_NAME
+          pre_release_title="Temporary release to build and test artifacts from PR#${{ github.event.pull_request.number }}"
+          pre_release_notes="Created by PR: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
+
+          echo "Creating pre-release: $pre_release_tag"
+          gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes"
 
       - name: Install python
         uses: actions/setup-python@v4
@@ -45,19 +56,18 @@ jobs:
         id: set-matrices
         run: |
           make versions
-          
           echo "linux_and_windows_matrix=$( cat versions/linuxAndWindowsMatrix.json )" >> "$GITHUB_OUTPUT"
 
   # Downloads all Fluent Bit packages that are officially supported, preferably from the New Relic Infrastructure Agent
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
   # If these are not available, they are downloaded from the official Fluent Bit repository and repackaged to be used by the NRIA.
   download_official_packages:
-    needs: [prepare_matrices]
+    needs: [setup_environment]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        include: ${{ fromJson(needs.prepare_matrices.outputs.linux_and_windows_matrix) }}
+        include: ${{ fromJson(needs.setup_environment.outputs.linux_and_windows_matrix) }}
     name: ${{ matrix.osDistro }}-${{ matrix.osVersion }}-${{ matrix.arch }}
     steps:
       - name: Check out repository
@@ -100,7 +110,23 @@ jobs:
           name: ${{ matrix.targetPackageName }}
           path: packages/${{ matrix.targetPackageName }}
 
+  upload_official_packages_to_prerelease:
+    needs: [ download_official_packages ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts from shared filesystem
+        uses: actions/download-artifact@v3
+        with:
+          path: packages
+
+      - name: Push all artifacts to pre-release
+        run:
+          # To understand the need for /*/*, see comment in "upload artifacts" step above
+          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/*
+
   spin_up_suse:
+    needs: [setup_environment]
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "terraform TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
@@ -120,44 +146,20 @@ jobs:
       container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-suse-builders PR_NUMBER=${{ github.event.pull_request.number }}"
     secrets: inherit
 
-  # Re-creates the GH prerelease on each commit and pushes all Fluent Bit packages there
-  prepare_prerelease:
-    if: github.event.action != 'closed'
-    needs: [ download_official_packages, build_suse_packages ]
+  sign_suse_packages:
+    needs: [build_suse_packages]
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: (Re)create pre-release
-        run: | 
-          pre_release_exists=$(gh release view $PRE_RELEASE_NAME &>/dev/null && echo "true" || echo "false")
-          if [[ $pre_release_exists == "true" ]]; then
-            gh release delete ${{ env.PRE_RELEASE_NAME }} -y --cleanup-tag
-          fi
-          
-          pre_release_tag=$PRE_RELEASE_NAME
-          pre_release_title="Temporary release to build and test artifacts from PR#${{ github.event.pull_request.number }}"
-          pre_release_notes="Created by PR: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
-
-          echo "Creating pre-release: $pre_release_tag"
-          gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes"
-
-      - name: Download all artifacts from shared filesystem
-        uses: actions/download-artifact@v3
-        with:
-          path: packages
-
-      - name: Push all artifacts to pre-release
+      - name: Sign STUB
         run:
-          # To understand the need for /*/*, see comment in "upload artifacts" step above
-          gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/*
+          echo "TODO"
+        
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:
-    needs: [ envSetup, prepare_prerelease]
+    needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
-      gh_release_name: ${{ needs.envSetup.outputs.PRE_RELEASE_NAME }}
+      gh_release_name: ${{ needs.setup_environment.outputs.pre_release_name }}
       infra_agent_version: latest

--- a/.github/workflows/run_task.yml
+++ b/.github/workflows/run_task.yml
@@ -37,7 +37,7 @@ jobs:
           aws_region: us-east-2
           container_make_target: ${{ inputs.container_make_target }}
           ecs_cluster_name: infra-agent-fb-e2e-testing
-          task_definition_name: infra-agent-fb-e2e-testing-td
+          task_definition_name: infra-agent-fb-e2e-testing
           cloud_watch_logs_group_name: infra-agent-fb-e2e-testing
           # The log stream name must follow the {cloudwatch_log_prefix}/{container_name}
           # that was used to create the ECS infrastructure. "ecs" is the default cloudwatch_log_prefix

--- a/.github/workflows/run_task.yml
+++ b/.github/workflows/run_task.yml
@@ -32,7 +32,7 @@ jobs:
           echo "GIT_BRANCH=$GIT_BRANCH" >> "$GITHUB_ENV"
 
       - name: Launch Fargate task
-        uses: jsubirat/fargate-runner-action@allow_passing_task_security_group
+        uses: newrelic/fargate-runner-action@main
         with:
           aws_region: us-east-2
           container_make_target: ${{ inputs.container_make_target }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ $(addsuffix -clean,$(TARGETS)):
 	$(MAKE) -C $(patsubst %-clean,%,$@) clean
 
 local:
-	docker run -it --platform=linux/amd64 -v $(shell pwd)/tools/local_testing_entrypoint.sh:/entrypoint.sh \
+	docker run -it --platform=linux/amd64 \
+        -v $(shell pwd)/tools/local_testing_entrypoint.sh:/entrypoint.sh \
 		-v $(shell pwd):/srv/fluent-bit-package \
 		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
 		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \

--- a/ansible/Ansible.common.mk
+++ b/ansible/Ansible.common.mk
@@ -1,0 +1,37 @@
+# Creates required folder structure, installs dependencies and sets the following environment variables for the calling project:
+# - ANSIBLE_FOLDER
+# - ANSIBLE_INVENTORY
+# - REQUIREMENTS_FILE
+# - ROLES_PATH
+# - COLLECTIONS_PATH
+
+ANSIBLE_FOLDER := $(CURDIR)
+ANSIBLE_INVENTORY_TEMPLATE := $(ANSIBLE_FOLDER)/aws_ec2.yml.dist
+ANSIBLE_INVENTORY := $(ANSIBLE_FOLDER)/aws_ec2.yml
+REQUIREMENTS_FILE := $(ANSIBLE_FOLDER)/requirements.yml
+ROLES_PATH := $(ANSIBLE_FOLDER)/roles
+COLLECTIONS_PATH := $(ANSIBLE_FOLDER)/collections
+
+# Creates "collections" and "roles" folders inside the calling Ansible project
+$(ROLES_PATH) $(COLLECTIONS_PATH):
+	@mkdir -p $@
+
+.PHONY: ansible/prepare-inventory
+ansible/prepare-inventory:
+	@sed "s/PR_NUMBER/${PR_NUMBER}/g" $(ANSIBLE_INVENTORY_TEMPLATE) > $(ANSIBLE_INVENTORY)
+
+# Installs dependencies into "collections" and "roles" folders
+.PHONY: ansible/dependencies
+ansible/dependencies: $(ROLES_PATH) $(COLLECTIONS_PATH)
+	# Requirements to manage EC2 instances using SSM. This should be moved into the fargate-runner-action Dockerfile
+	pip3 install boto3
+	curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+	dpkg -i session-manager-plugin.deb
+
+	ansible-galaxy role install -r $(REQUIREMENTS_FILE) -p $(ROLES_PATH)
+	ansible-galaxy collection install -r $(REQUIREMENTS_FILE) -p $(COLLECTIONS_PATH)
+
+# Removes "collections" and "roles" folders
+.PHONY: ansible/clean
+ansible/clean:
+	rm -rf $(ROLES_PATH) $(COLLECTIONS_PATH)

--- a/ansible/build-fb-suse/Makefile
+++ b/ansible/build-fb-suse/Makefile
@@ -1,0 +1,10 @@
+include ../Ansible.common.mk
+
+.DEFAULT_GOAL := build-fb-suse
+
+.PHONY: build-fb-suse
+build-fb-suse: ansible/dependencies ansible/prepare-inventory
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
+
+.PHONY: clean
+clean: ansible/clean

--- a/ansible/build-fb-suse/Makefile
+++ b/ansible/build-fb-suse/Makefile
@@ -4,7 +4,9 @@ include ../Ansible.common.mk
 
 .PHONY: build-fb-suse
 build-fb-suse: ansible/dependencies ansible/prepare-inventory
-	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY) -vvv
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
+	@sed "s/PR_NUMBER/${PR_NUMBER}/g" playbook-localhost.yml.dist > playbook-localhost.yml
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook-localhost.yml
 
 .PHONY: clean
 clean: ansible/clean

--- a/ansible/build-fb-suse/Makefile
+++ b/ansible/build-fb-suse/Makefile
@@ -4,7 +4,7 @@ include ../Ansible.common.mk
 
 .PHONY: build-fb-suse
 build-fb-suse: ansible/dependencies ansible/prepare-inventory
-	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY) -vvv
 
 .PHONY: clean
 clean: ansible/clean

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -12,7 +12,7 @@ hostnames:
 filters:
     tag:pr_number: PR_NUMBER
     tag:os_distro: sles
-    tag:name_suffix: fluentbit-builder
+    tag:instance_type: fluentbit-builder
 groups:
     suse_12: "tags.os_version.startswith('12')"
     suse_15: "tags.os_version.startswith('15')"

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -10,6 +10,11 @@ hostnames:
     # This is how each host will be displayed when executing the Ansible playbook.
     - tag:Name
 filters:
+    # Mandatory tags
+    tag:product: logging
+    tag:owning_team: logging
+    tag:project: fluent-bit-packaging-and-testing
+    # Select instances to run this playbook on
     tag:pr_number: PR_NUMBER
     tag:os_distro: sles
     tag:instance_type: fluentbit-builder

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -1,0 +1,26 @@
+# Configuration reference:
+# - https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/aws_ec2_guide.html
+# - https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html
+
+plugin: aws_ec2
+regions:
+    - us-east-2
+hostnames:
+    # This is how each host will be displayed when executing the Ansible playbook.
+    - tag:Name
+filters:
+    tag:pr_number: PR_NUMBER
+    tag:os_distro: sles
+    tag:name_suffix: fluentbit-builder
+groups:
+    suse_12: "tags.os_version.startswith('12')"
+    suse_15: "tags.os_version.startswith('15')"
+compose:
+    # This is how the Ansible SSM plugin will connect to each host. We cannot use the hostname (tag:Name) directly because
+    # it contains "." characters, which are not allowed by the SSM plugin.
+    ansible_host: instance_id
+    # Host variables that are strings (not variables) need to be wrapped with two sets of quotes.
+    # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
+    ansible_connection: '"community.aws.aws_ssm"'
+    ansible_aws_ssm_bucket_name: '"jsubirats-temp-ansible-removeme"'
+    ansible_aws_ssm_region: '"us-east-2"'

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -22,5 +22,5 @@ compose:
     # Host variables that are strings (not variables) need to be wrapped with two sets of quotes.
     # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
     ansible_connection: '"community.aws.aws_ssm"'
-    # ansible_aws_ssm_bucket_name: '"jsubirats-temp-ansible-removeme"'
+    ansible_aws_ssm_bucket_name: '"logging-e2e-testing-ssm-transfers"'
     ansible_aws_ssm_region: '"us-east-2"'

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -1,6 +1,7 @@
 # Configuration reference:
 # - https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/aws_ec2_guide.html
 # - https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html
+# - https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html
 
 plugin: aws_ec2
 regions:
@@ -23,4 +24,5 @@ compose:
     # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
     ansible_connection: '"community.aws.aws_ssm"'
     ansible_aws_ssm_bucket_name: '"logging-e2e-testing-ssm-transfers"'
+    ansible_aws_ssm_bucket_sse_mode: '"AES256"'
     ansible_aws_ssm_region: '"us-east-2"'

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -10,10 +10,6 @@ hostnames:
     # This is how each host will be displayed when executing the Ansible playbook.
     - tag:Name
 filters:
-    # Mandatory tags
-    tag:product: logging
-    tag:owning_team: logging
-    tag:project: fluent-bit-packaging-and-testing
     # Select instances to run this playbook on
     tag:pr_number: PR_NUMBER
     tag:os_distro: sles

--- a/ansible/build-fb-suse/aws_ec2.yml.dist
+++ b/ansible/build-fb-suse/aws_ec2.yml.dist
@@ -22,5 +22,5 @@ compose:
     # Host variables that are strings (not variables) need to be wrapped with two sets of quotes.
     # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
     ansible_connection: '"community.aws.aws_ssm"'
-    ansible_aws_ssm_bucket_name: '"jsubirats-temp-ansible-removeme"'
+    # ansible_aws_ssm_bucket_name: '"jsubirats-temp-ansible-removeme"'
     ansible_aws_ssm_region: '"us-east-2"'

--- a/ansible/build-fb-suse/group_vars/suse_12.yml
+++ b/ansible/build-fb-suse/group_vars/suse_12.yml
@@ -1,0 +1,7 @@
+# SUSE 12 contains Python 2.7 and 3.4. Ansible requires a minimum of Python 2.7 or 3.5 to work.
+# Due to this issue (https://github.com/ansible/ansible/issues/77840#issuecomment-1252321964),
+# it tries Python 3 only, and when gathering the facts from the remote SUSE server it
+# discovers it is running a too old Python 3 (3.4 < 3.5) version. We need to instruct it to
+# explicitly use Python 2.7 for it to work.
+ansible_python_interpreter: /usr/bin/python
+cpp_with_version: cpp48

--- a/ansible/build-fb-suse/group_vars/suse_15.yml
+++ b/ansible/build-fb-suse/group_vars/suse_15.yml
@@ -1,0 +1,2 @@
+ansible_python_interpreter: /usr/bin/python3
+cpp_with_version: cpp7

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -1,0 +1,9 @@
+- name: Publish SUSE packages to GH pre-release
+  hosts: localhost
+  vars:
+    pr_number: PR_NUMBER
+  roles:
+    - andrewrothstein.gh
+  tasks:
+    - name: Upload generated artifacts to release
+      command: "gh release upload tmp-pr-{{ pr_number }} /tmp/fluent-bit-suse-packages/*"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -12,10 +12,6 @@
         recurse: yes
       register: directory_contents
 
-    - name: Display package list
-      debug:
-        var: directory_contents.files
-
     - name: Upload generated artifacts to release
       command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}"
       loop: "{{ directory_contents.files }}"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -13,5 +13,5 @@
       register: directory_contents
 
     - name: Upload generated artifacts to release
-      command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}"
+      command: "gh release upload tmp-pr-{{ pr_number }} {{ item.path }}"
       loop: "{{ directory_contents.files }}"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -17,5 +17,5 @@
         var: directory_contents.files
 
     - name: Upload generated artifacts to release
-      command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}/*"
+      command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}"
       loop: "{{ directory_contents.files }}"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -18,4 +18,4 @@
 
     - name: Upload generated artifacts to release
       command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}/*"
-      with_items: "{{ directory_contents.files }}"
+      loop: "{{ directory_contents.files }}"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -2,8 +2,19 @@
   hosts: localhost
   vars:
     pr_number: PR_NUMBER
+    suse_packages_dir: /tmp/fluent-bit-suse-packages
   roles:
     - andrewrothstein.gh
   tasks:
+    - name: List packages to be uploaded
+      find:
+        paths: "{{ suse_packages_dir }}"
+        recurse: yes
+      register: directory_contents
+
+    - name: Display package list
+      debug:
+        var: directory_contents.files
+
     - name: Upload generated artifacts to release
-      command: "gh release upload tmp-pr-{{ pr_number }} /tmp/fluent-bit-suse-packages/*"
+      command: "gh release upload tmp-pr-{{ pr_number }} {{ suse_packages_dir }}/*"

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -17,4 +17,5 @@
         var: directory_contents.files
 
     - name: Upload generated artifacts to release
-      command: "gh release upload tmp-pr-{{ pr_number }} {{ suse_packages_dir }}/*"
+      command: "gh release upload --clobber tmp-pr-{{ pr_number }} {{ item.path }}/*"
+      with_items: "{{ directory_contents.files }}"

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -106,6 +106,8 @@
         chdir: "{{ fluent_bit_path }}/build"
       # Sometimes, SSM may experience timeouts due to how long this command takes. Retrying will proceed with the compilation
       # more or less where it left off, thanks to how "make" operates, so next attempts are more prone to succeed without timeout.
+      register: compilation_status
+      until: compilation_status is success
       delay: 15
       retries: 5
 

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -28,92 +28,92 @@
     - name: Wait for connection to be available
       wait_for_connection:
 
-#    - name: Install dependencies
-#      community.general.zypper:
-#        name: "{{ item }}"
-#        state: present
-#        oldpackage: true
-#        force_resolution: true
-#      loop:
-#        - git
-#        - flex
-#        - wget
-#        - libyaml-devel
-#        - libopenssl-devel
-#        - systemd-devel
-#        - gcc
-#        - gcc-c++
-#        - rpmbuild
-#        - "{{ cpp_with_version }}"
-#      become: true
-#      register: install_status
-#      until: install_status is success
-#      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
-#      delay: 15
-#      retries: 10
-#
-#    - name: Download and extract Bison {{ bison_version }}
-#      unarchive:
-#        src: http://ftp.gnu.org/gnu/bison/bison-{{ bison_version }}.tar.gz
-#        dest: "{{ home_path }}"
-#        remote_src: yes
-#        creates: "{{ bison_path }}"
-#
-#    - name: Configure Bison {{ bison_version }}
-#      command:
-#        cmd: ./configure
-#        chdir: "{{ bison_path }}"
-#        creates: "{{ bison_path }}/Makefile"
-#
-#    - name: Build Bison {{ bison_version }}
-#      make:
-#        chdir: "{{ bison_path }}"
-#
-#    - name: Install Bison {{ bison_version }}
-#      make:
-#        chdir: "{{ bison_path }}"
-#        target: install
-#      become: true
-#
-#    - name: Create symbolic link for Bison {{ bison_version }} in /usr/bin
-#      file:
-#        src: /usr/local/bin/bison
-#        dest: /usr/bin/bison
-#        state: link
-#      become: true
-#
-#    - name: Download and extract Cmake {{ cmake_version }}
-#      unarchive:
-#        src: "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-linux-x86_64.tar.gz"
-#        dest: "{{ home_path }}"
-#        remote_src: yes
-#        creates: "{{ cmake_path }}"
-#
-#    - name: Checkout Fluent Bit {{ fluent_bit_version }}
-#      git:
-#        repo: 'https://github.com/fluent/fluent-bit.git'
-#        dest: "{{ fluent_bit_path }}"
-#        version: "v{{ fluent_bit_version }}"
-#
-#    - name: Configure Fluent Bit {{ fluent_bit_version }}
-#      command:
-#        cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
-#        chdir: "{{ fluent_bit_path }}/build"
-#        creates: "{{ fluent_bit_path }}/Makefile"
-#
-#    - name: Build Fluent Bit {{ fluent_bit_version }}
-#      make:
-#        chdir: "{{ fluent_bit_path }}/build"
-#
-#    - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
-#      command:
-#        cmd: "{{ cmake_path }}/bin/cpack -G RPM"
-#        chdir: "{{ fluent_bit_path }}/build"
-#        creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
-#
-#    - name: Rename binary for the specific OS type, version and arch
-#      # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
-#      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
+    - name: Install dependencies
+      community.general.zypper:
+        name: "{{ item }}"
+        state: present
+        oldpackage: true
+        force_resolution: true
+      loop:
+        - git
+        - flex
+        - wget
+        - libyaml-devel
+        - libopenssl-devel
+        - systemd-devel
+        - gcc
+        - gcc-c++
+        - rpmbuild
+        - "{{ cpp_with_version }}"
+      become: true
+      register: install_status
+      until: install_status is success
+      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
+      delay: 15
+      retries: 10
+
+    - name: Download and extract Bison {{ bison_version }}
+      unarchive:
+        src: http://ftp.gnu.org/gnu/bison/bison-{{ bison_version }}.tar.gz
+        dest: "{{ home_path }}"
+        remote_src: yes
+        creates: "{{ bison_path }}"
+
+    - name: Configure Bison {{ bison_version }}
+      command:
+        cmd: ./configure
+        chdir: "{{ bison_path }}"
+        creates: "{{ bison_path }}/Makefile"
+
+    - name: Build Bison {{ bison_version }}
+      make:
+        chdir: "{{ bison_path }}"
+
+    - name: Install Bison {{ bison_version }}
+      make:
+        chdir: "{{ bison_path }}"
+        target: install
+      become: true
+
+    - name: Create symbolic link for Bison {{ bison_version }} in /usr/bin
+      file:
+        src: /usr/local/bin/bison
+        dest: /usr/bin/bison
+        state: link
+      become: true
+
+    - name: Download and extract Cmake {{ cmake_version }}
+      unarchive:
+        src: "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-linux-x86_64.tar.gz"
+        dest: "{{ home_path }}"
+        remote_src: yes
+        creates: "{{ cmake_path }}"
+
+    - name: Checkout Fluent Bit {{ fluent_bit_version }}
+      git:
+        repo: 'https://github.com/fluent/fluent-bit.git'
+        dest: "{{ fluent_bit_path }}"
+        version: "v{{ fluent_bit_version }}"
+
+    - name: Configure Fluent Bit {{ fluent_bit_version }}
+      command:
+        cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
+        chdir: "{{ fluent_bit_path }}/build"
+        creates: "{{ fluent_bit_path }}/Makefile"
+
+    - name: Build Fluent Bit {{ fluent_bit_version }}
+      make:
+        chdir: "{{ fluent_bit_path }}/build"
+
+    - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
+      command:
+        cmd: "{{ cmake_path }}/bin/cpack -G RPM"
+        chdir: "{{ fluent_bit_path }}/build"
+        creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
+
+    - name: Rename binary for the specific OS type, version and arch
+      # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
+      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
 
     - name: Download generated Fluent Bit RPM package
       fetch:

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -46,6 +46,11 @@
         - rpmbuild
         - "{{ cpp_with_version }}"
       become: true
+      register: install_status
+      until: install_status is success
+      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
+      delay: 15
+      retries: 10
 
     - name: Download and extract Bison {{ bison_version }}
       unarchive:
@@ -106,8 +111,12 @@
         chdir: "{{ fluent_bit_path }}/build"
         creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
 
+    - name: Rename binary for the specific OS type, version and arch
+      # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
+      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
+
     - name: Download generated Fluent Bit RPM package
       fetch:
-        src: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
-        dest: "/tmp/fluent-bit-suse-packages/{{ fluent_bit_package_name }}"
+        src: "{{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
+        dest: "/tmp/fluent-bit-suse-packages/"
         flat: yes

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -119,7 +119,10 @@
 
     - name: Rename binary for the specific OS type, version and arch
       # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
-      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
+      command:
+        cmd: "cp fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_package_name }}"
+        chdir: "{{ fluent_bit_path }}/build"
+        creates: "{{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
 
     - name: Download generated Fluent Bit RPM package
       fetch:

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -6,6 +6,7 @@
 # - git module: https://docs.ansible.com/ansible/2.9/modules/git_module.html#git-module
 # - make module: https://docs.ansible.com/ansible/2.9/modules/make_module.html#make-module
 # - Fluent Bit compilation: https://docs.fluentbit.io/manual/installation/sources/build-and-install
+# -ansible.builtin.fetch module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/fetch_module.html
 
 - name: Provision SUSE instances and compile Fluent Bit
   hosts: all
@@ -16,8 +17,13 @@
     # We need cmake 3.23.0 at least, as the one present in SLES 12.X is too old for Fluent Bit
     cmake_version: 3.23.0
     cmake_path: "{{ home_path }}/cmake-{{ cmake_version }}-linux-x86_64"
-    fluent_bit_version: 2.0.8
     fluent_bit_path: "{{ home_path }}/fluent-bit"
+    # The following information is populated using the gathered inventory variables
+    fluent_bit_version: "{{ tags.fb_version }}"
+    os_distro: "{{ tags.os_distro }}"
+    os_version: "{{ tags.os_version }}"
+    arch: "{{ tags.arch }}"
+    fluent_bit_package_name: "fluent-bit-{{ fluent_bit_version }}-1.{{ os_distro }}{{ os_version }}.{{ arch }}.rpm"
   tasks:
     - name: Wait for connection to be available
       wait_for_connection:
@@ -99,3 +105,9 @@
         cmd: "{{ cmake_path }}/bin/cpack -G RPM"
         chdir: "{{ fluent_bit_path }}/build"
         creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
+
+    - name: Download generated Fluent Bit RPM package
+      fetch:
+        src: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
+        dest: "/tmp/fluent-bit-suse-packages/{{ fluent_bit_package_name }}"
+        flat: yes

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -1,0 +1,101 @@
+# References:
+# - community.general.zypper module: https://docs.ansible.com/ansible/latest/collections/community/general/zypper_module.html
+# - unarchive module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/unarchive_module.html
+# - ansible.builtin.command module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html
+# - ansible.builtin.file module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#ansible-collections-ansible-builtin-file-module
+# - git module: https://docs.ansible.com/ansible/2.9/modules/git_module.html#git-module
+# - make module: https://docs.ansible.com/ansible/2.9/modules/make_module.html#make-module
+# - Fluent Bit compilation: https://docs.fluentbit.io/manual/installation/sources/build-and-install
+
+- name: Provision SUSE instances and compile Fluent Bit
+  hosts: all
+  vars:
+    home_path: /home/ssm-user
+    bison_version: 3.7
+    bison_path: "{{ home_path }}/bison-{{ bison_version }}"
+    # We need cmake 3.23.0 at least, as the one present in SLES 12.X is too old for Fluent Bit
+    cmake_version: 3.23.0
+    cmake_path: "{{ home_path }}/cmake-{{ cmake_version }}-linux-x86_64"
+    fluent_bit_version: 2.0.8
+    fluent_bit_path: "{{ home_path }}/fluent-bit"
+  tasks:
+    - name: Wait for connection to be available
+      wait_for_connection:
+
+    - name: Install dependencies
+      community.general.zypper:
+        name: "{{ item }}"
+        state: present
+        oldpackage: true
+        force_resolution: true
+      loop:
+        - git
+        - flex
+        - wget
+        - libyaml-devel
+        - libopenssl-devel
+        - systemd-devel
+        - gcc
+        - gcc-c++
+        - rpmbuild
+        - "{{ cpp_with_version }}"
+      become: true
+
+    - name: Download and extract Bison {{ bison_version }}
+      unarchive:
+        src: http://ftp.gnu.org/gnu/bison/bison-{{ bison_version }}.tar.gz
+        dest: "{{ home_path }}"
+        remote_src: yes
+        creates: "{{ bison_path }}"
+
+    - name: Configure Bison {{ bison_version }}
+      command:
+        cmd: ./configure
+        chdir: "{{ bison_path }}"
+        creates: "{{ bison_path }}/Makefile"
+
+    - name: Build Bison {{ bison_version }}
+      make:
+        chdir: "{{ bison_path }}"
+
+    - name: Install Bison {{ bison_version }}
+      make:
+        chdir: "{{ bison_path }}"
+        target: install
+      become: true
+
+    - name: Create symbolic link for Bison {{ bison_version }} in /usr/bin
+      file:
+        src: /usr/local/bin/bison
+        dest: /usr/bin/bison
+        state: link
+      become: true
+
+    - name: Download and extract Cmake {{ cmake_version }}
+      unarchive:
+        src: "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-linux-x86_64.tar.gz"
+        dest: "{{ home_path }}"
+        remote_src: yes
+        creates: "{{ cmake_path }}"
+
+    - name: Checkout Fluent Bit {{ fluent_bit_version }}
+      git:
+        repo: 'https://github.com/fluent/fluent-bit.git'
+        dest: "{{ fluent_bit_path }}"
+        version: "v{{ fluent_bit_version }}"
+
+    - name: Configure Fluent Bit {{ fluent_bit_version }}
+      command:
+        cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
+        chdir: "{{ fluent_bit_path }}/build"
+        creates: "{{ fluent_bit_path }}/Makefile"
+
+    - name: Build Fluent Bit {{ fluent_bit_version }}
+      make:
+        chdir: "{{ fluent_bit_path }}/build"
+
+    - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
+      command:
+        cmd: "{{ cmake_path }}/bin/cpack -G RPM"
+        chdir: "{{ fluent_bit_path }}/build"
+        creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -28,92 +28,92 @@
     - name: Wait for connection to be available
       wait_for_connection:
 
-    - name: Install dependencies
-      community.general.zypper:
-        name: "{{ item }}"
-        state: present
-        oldpackage: true
-        force_resolution: true
-      loop:
-        - git
-        - flex
-        - wget
-        - libyaml-devel
-        - libopenssl-devel
-        - systemd-devel
-        - gcc
-        - gcc-c++
-        - rpmbuild
-        - "{{ cpp_with_version }}"
-      become: true
-      register: install_status
-      until: install_status is success
-      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
-      delay: 15
-      retries: 10
-
-    - name: Download and extract Bison {{ bison_version }}
-      unarchive:
-        src: http://ftp.gnu.org/gnu/bison/bison-{{ bison_version }}.tar.gz
-        dest: "{{ home_path }}"
-        remote_src: yes
-        creates: "{{ bison_path }}"
-
-    - name: Configure Bison {{ bison_version }}
-      command:
-        cmd: ./configure
-        chdir: "{{ bison_path }}"
-        creates: "{{ bison_path }}/Makefile"
-
-    - name: Build Bison {{ bison_version }}
-      make:
-        chdir: "{{ bison_path }}"
-
-    - name: Install Bison {{ bison_version }}
-      make:
-        chdir: "{{ bison_path }}"
-        target: install
-      become: true
-
-    - name: Create symbolic link for Bison {{ bison_version }} in /usr/bin
-      file:
-        src: /usr/local/bin/bison
-        dest: /usr/bin/bison
-        state: link
-      become: true
-
-    - name: Download and extract Cmake {{ cmake_version }}
-      unarchive:
-        src: "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-linux-x86_64.tar.gz"
-        dest: "{{ home_path }}"
-        remote_src: yes
-        creates: "{{ cmake_path }}"
-
-    - name: Checkout Fluent Bit {{ fluent_bit_version }}
-      git:
-        repo: 'https://github.com/fluent/fluent-bit.git'
-        dest: "{{ fluent_bit_path }}"
-        version: "v{{ fluent_bit_version }}"
-
-    - name: Configure Fluent Bit {{ fluent_bit_version }}
-      command:
-        cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
-        chdir: "{{ fluent_bit_path }}/build"
-        creates: "{{ fluent_bit_path }}/Makefile"
-
-    - name: Build Fluent Bit {{ fluent_bit_version }}
-      make:
-        chdir: "{{ fluent_bit_path }}/build"
-
-    - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
-      command:
-        cmd: "{{ cmake_path }}/bin/cpack -G RPM"
-        chdir: "{{ fluent_bit_path }}/build"
-        creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
-
-    - name: Rename binary for the specific OS type, version and arch
-      # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
-      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
+#    - name: Install dependencies
+#      community.general.zypper:
+#        name: "{{ item }}"
+#        state: present
+#        oldpackage: true
+#        force_resolution: true
+#      loop:
+#        - git
+#        - flex
+#        - wget
+#        - libyaml-devel
+#        - libopenssl-devel
+#        - systemd-devel
+#        - gcc
+#        - gcc-c++
+#        - rpmbuild
+#        - "{{ cpp_with_version }}"
+#      become: true
+#      register: install_status
+#      until: install_status is success
+#      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
+#      delay: 15
+#      retries: 10
+#
+#    - name: Download and extract Bison {{ bison_version }}
+#      unarchive:
+#        src: http://ftp.gnu.org/gnu/bison/bison-{{ bison_version }}.tar.gz
+#        dest: "{{ home_path }}"
+#        remote_src: yes
+#        creates: "{{ bison_path }}"
+#
+#    - name: Configure Bison {{ bison_version }}
+#      command:
+#        cmd: ./configure
+#        chdir: "{{ bison_path }}"
+#        creates: "{{ bison_path }}/Makefile"
+#
+#    - name: Build Bison {{ bison_version }}
+#      make:
+#        chdir: "{{ bison_path }}"
+#
+#    - name: Install Bison {{ bison_version }}
+#      make:
+#        chdir: "{{ bison_path }}"
+#        target: install
+#      become: true
+#
+#    - name: Create symbolic link for Bison {{ bison_version }} in /usr/bin
+#      file:
+#        src: /usr/local/bin/bison
+#        dest: /usr/bin/bison
+#        state: link
+#      become: true
+#
+#    - name: Download and extract Cmake {{ cmake_version }}
+#      unarchive:
+#        src: "https://github.com/Kitware/CMake/releases/download/v{{ cmake_version }}/cmake-{{ cmake_version }}-linux-x86_64.tar.gz"
+#        dest: "{{ home_path }}"
+#        remote_src: yes
+#        creates: "{{ cmake_path }}"
+#
+#    - name: Checkout Fluent Bit {{ fluent_bit_version }}
+#      git:
+#        repo: 'https://github.com/fluent/fluent-bit.git'
+#        dest: "{{ fluent_bit_path }}"
+#        version: "v{{ fluent_bit_version }}"
+#
+#    - name: Configure Fluent Bit {{ fluent_bit_version }}
+#      command:
+#        cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
+#        chdir: "{{ fluent_bit_path }}/build"
+#        creates: "{{ fluent_bit_path }}/Makefile"
+#
+#    - name: Build Fluent Bit {{ fluent_bit_version }}
+#      make:
+#        chdir: "{{ fluent_bit_path }}/build"
+#
+#    - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
+#      command:
+#        cmd: "{{ cmake_path }}/bin/cpack -G RPM"
+#        chdir: "{{ fluent_bit_path }}/build"
+#        creates: "{{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm"
+#
+#    - name: Rename binary for the specific OS type, version and arch
+#      # Not actually renaming but copying, so that the previous step nor this one won't be re-executed thanks to "creates"
+#      command: "cp {{ fluent_bit_path }}/build/fluent-bit-{{ fluent_bit_version }}-1.x86_64.rpm {{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
 
     - name: Download generated Fluent Bit RPM package
       fetch:

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -104,6 +104,10 @@
     - name: Build Fluent Bit {{ fluent_bit_version }}
       make:
         chdir: "{{ fluent_bit_path }}/build"
+      # Sometimes, SSM may experience timeouts due to how long this command takes. Retrying will proceed with the compilation
+      # more or less where it left off, thanks to how "make" operates, so next attempts are more prone to succeed without timeout.
+      delay: 15
+      retries: 5
 
     - name: Create SUSE RPM package for Fluent Bit {{ fluent_bit_version }}
       command:

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -119,4 +119,4 @@
       fetch:
         src: "{{ fluent_bit_path }}/build/{{ fluent_bit_package_name }}"
         dest: "/tmp/fluent-bit-suse-packages/"
-        flat: yes
+        flat: true

--- a/ansible/build-fb-suse/requirements.yml
+++ b/ansible/build-fb-suse/requirements.yml
@@ -1,0 +1,3 @@
+collections: []
+
+roles: []

--- a/ansible/build-fb-suse/requirements.yml
+++ b/ansible/build-fb-suse/requirements.yml
@@ -1,3 +1,4 @@
 collections: []
 
-roles: []
+roles:
+  - name: andrewrothstein.gh

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -19,7 +19,7 @@ terraform/backend: checks
 	@if [ ! -d "./${TERRAFORM_PROJECT}" ]; then \
   		echo "Terraform project ${TERRAFORM_PROJECT} does not exist"; \
 	fi
-	@echo "Creating Terraform state file in ./${TERRAFORM_PROJECT}/terraform.backend.tf from template in ./${TERRAFORM_PROJECT}/terraform.backend.tf.dist"
+	@echo "Creating Terraform backend file in ./${TERRAFORM_PROJECT}/terraform.backend.tf from template in ./${TERRAFORM_PROJECT}/terraform.backend.tf.dist"
 	@sed "s/PR_NUMBER/${PR_NUMBER}/g" "./${TERRAFORM_PROJECT}/terraform.backend.tf.dist" > "./${TERRAFORM_PROJECT}/terraform.backend.tf"
 
 # Exports environment variables that are accessed by the launched Terraform project

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -2,7 +2,6 @@ locals {
   # Available fields in each element:
   #  {
   #    "fbVersion": "2.0.7",
-  #    "ec2User": "centos",
   #    "osDistro": "centos",
   #    "osVersion": 9,
   #    "arch": "x86_64",
@@ -38,7 +37,7 @@ EOF
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
 
-  for_each = { for pkg in local.instance_matrix : "pr-${var.pr_number}-${pkg.osDistro}-${pkg.osVersion}-${pkg.arch}-fb-${pkg.fbVersion}-builder" => pkg }
+  for_each = { for pkg in local.instance_matrix : "pr-${var.pr_number}-${pkg.osDistro}-${pkg.osVersion}-${pkg.arch}-fb-${pkg.fbVersion}-${var.name_suffix}" => pkg }
 
   name = each.key
 
@@ -51,5 +50,12 @@ module "ec2_instance" {
 
   user_data = each.value.osDistro == "windows-server" ? local.windows_data_boot_script_for_ssm : local.linux_user_data_boot_script_for_ssm
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, {
+    pr_number = var.pr_number
+    os_distro = each.value.osDistro
+    os_version = each.value.osVersion
+    arch = each.value.arch
+    fb_version = each.value.fbVersion
+    name_suffix = var.name_suffix
+  })
 }

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -37,7 +37,7 @@ EOF
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
 
-  for_each = { for pkg in local.instance_matrix : "pr-${var.pr_number}-${pkg.osDistro}-${pkg.osVersion}-${pkg.arch}-fb-${pkg.fbVersion}-${var.name_suffix}" => pkg }
+  for_each = { for pkg in local.instance_matrix : "pr-${var.pr_number}-${pkg.osDistro}-${pkg.osVersion}-${pkg.arch}-fb-${pkg.fbVersion}-${var.instance_type}" => pkg }
 
   name = each.key
 

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -59,6 +59,6 @@ module "ec2_instance" {
     os_version = each.value.osVersion
     arch = each.value.arch
     fb_version = each.value.fbVersion
-    name_suffix = var.name_suffix
+    instance_type = var.instance_type
   })
 }

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -61,4 +61,13 @@ module "ec2_instance" {
     fb_version = each.value.fbVersion
     instance_type = var.instance_type
   })
+
+  volume_tags = merge(local.default_tags, {
+    pr_number = var.pr_number
+    os_distro = each.value.osDistro
+    os_version = each.value.osVersion
+    arch = each.value.arch
+    fb_version = each.value.fbVersion
+    instance_type = var.instance_type
+  })
 }

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -50,6 +50,9 @@ module "ec2_instance" {
 
   user_data = each.value.osDistro == "windows-server" ? local.windows_data_boot_script_for_ssm : local.linux_user_data_boot_script_for_ssm
 
+  # Include fields from the strategy matrix into the EC2 instance tags. Thanks to this, we are able to know which Fluent
+  # Bit version and for which OS version and arch is each EC2 instance meant to compile/test. This is later read in the
+  # Ansible playbooks as variables.
   tags = merge(local.default_tags, {
     pr_number = var.pr_number
     os_distro = each.value.osDistro

--- a/terraform/ec2-instances-creator/variables.tf
+++ b/terraform/ec2-instances-creator/variables.tf
@@ -7,3 +7,8 @@ variable "pr_number" {
   type = string
   description = "Pull request number"
 }
+
+variable "name_suffix" {
+  type = string
+  description = "Name suffix to indicate what the created EC2 instances are for. Examples: 'fluentbit-tester', 'fluentbit-builder'"
+}

--- a/terraform/ec2-instances-creator/variables.tf
+++ b/terraform/ec2-instances-creator/variables.tf
@@ -8,7 +8,7 @@ variable "pr_number" {
   description = "Pull request number"
 }
 
-variable "name_suffix" {
+variable "instance_type" {
   type = string
-  description = "Name suffix to indicate what the created EC2 instances are for. Examples: 'fluentbit-tester', 'fluentbit-builder'"
+  description = "Indicates what the created EC2 instances are for. Examples: 'fluentbit-tester', 'fluentbit-builder'. This is later used by the Ansible dynamic inventory (see ansible/build-fb-suse/aws_ec2.yml.dist) to filter out the instances based on their type."
 }

--- a/terraform/ec2-suse-builders/main.tf
+++ b/terraform/ec2-suse-builders/main.tf
@@ -8,4 +8,5 @@ module "suse-fb-builder-instances" {
 
   instance_matrix_file = local.suse_matrix_path
   pr_number = var.pr_number
+  name_suffix = "fluentbit-builder"
 }

--- a/terraform/ec2-suse-builders/main.tf
+++ b/terraform/ec2-suse-builders/main.tf
@@ -8,5 +8,5 @@ module "suse-fb-builder-instances" {
 
   instance_matrix_file = local.suse_matrix_path
   pr_number = var.pr_number
-  name_suffix = "fluentbit-builder"
+  instance_type = "fluentbit-builder"
 }


### PR DESCRIPTION
This pull request introduces the following changes:
- It uses Ansible to provision (install dependencies) the Fluent Bit builder EC2 instances, proceed to build Fluent Bit in all of them, and then publish the results to the GitHub pre-release.
- The flow of the `pull_request.yml` workflow has been modified to first empty the GH pre-release and then proceed to launch the job to download the official packages and to build the SUSE ones.
- A new Makefile has been introduced inside the `ansible` directory to allow launching it from GH using the `fargate-task-runner` action.
- Ansible has been configured to leverage from SSM to connect to the instances, and to build the Ansible inventory using dynamic host discovery by filtering them using tags. This prevents us from having to build an inventory with the private IP addresses of the hosts and using SSH keys.
- As a result of this PR, now all the official packages for Linux and Windows as well as the unofficial ones (compiled by us, namely SUSE) are available to proceed with their testing.
- Indicatory comments have been provided to facilitate the review process.