### PR TITLE
Removes unnecessary ec2User attribute as we now use SSM

### DIFF
--- a/versions/centos_7.yml
+++ b/versions/centos_7.yml
@@ -1,6 +1,5 @@
 osDistro: centos
 osVersion: 7
-ec2User: centos
 packages:
   - arch: x86_64
     ami: ami-02358d9f5245918a3

--- a/versions/centos_8.yml
+++ b/versions/centos_8.yml
@@ -1,6 +1,5 @@
 osDistro: centos
 osVersion: 8
-ec2User: centos
 packages:
   - arch: x86_64
     ami: ami-0c07df890a618c98a

--- a/versions/centos_9.yml
+++ b/versions/centos_9.yml
@@ -1,6 +1,5 @@
 osDistro: centos
 osVersion: 9
-ec2User: centos
 packages:
   - arch: x86_64
     ami: ami-08c92aec9ccf0e1e9

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,5 +1,4 @@
 fbVersion: 2.0.8
-ec2User: ec2-user
 
 #  This file, together with each distro file are processed and merged incrementally to
 #  build all the information required to download and test each package. Each package ends
@@ -7,7 +6,6 @@ ec2User: ec2-user
 #
 #  {
 #    "fbVersion": "2.0.8",
-#    "ec2User": "admin",
 #    "osDistro": "debian",
 #    "osVersion": "bookworm",
 #    "arch": "amd64",

--- a/versions/debian_10_buster.yml
+++ b/versions/debian_10_buster.yml
@@ -1,6 +1,5 @@
 osDistro: debian
 osVersion: buster
-ec2User: admin
 packages:
   - arch: amd64
     ami: ami-07d02ee1eeb0c996c

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -1,6 +1,5 @@
 osDistro: debian
 osVersion: bullseye
-ec2User: admin
 packages:
   - arch: amd64
     ami: ami-052465340e6b59fc0

--- a/versions/debian_12_bookworm.yml
+++ b/versions/debian_12_bookworm.yml
@@ -1,6 +1,5 @@
 osDistro: debian
 osVersion: bookworm
-ec2User: admin
 packages:
   - arch: amd64
     ami: ami-08ca7cb88210133e5

--- a/versions/strategyMatrix.py
+++ b/versions/strategyMatrix.py
@@ -15,12 +15,10 @@ the following values:
 
     ---common.yml
     fbVersion: 2.0.8
-    ec2User: ec2-user
 
     ---centos_9.yml
     osDistro: centos
     osVersion: 9
-    ec2User: centos      // Overrides value from "common.yml
     fbVersion: 2.0.7     // Overrides value from "common.yml"
     packages:
       - arch: x86_64
@@ -33,7 +31,6 @@ This results in the following JSON objects in the resulting strategy matrix (rep
 
 {
     "fbVersion": "2.0.7",
-    "ec2User": "centos",
     "osDistro": "centos",
     "osVersion": 9,
     "arch": "x86_64",
@@ -44,7 +41,6 @@ This results in the following JSON objects in the resulting strategy matrix (rep
   },
   {
     "fbVersion": "2.0.6",
-    "ec2User": "centos",
     "osDistro": "centos",
     "osVersion": 9,
     "arch": "aarch64",

--- a/versions/ubuntu_18_bionic.yml
+++ b/versions/ubuntu_18_bionic.yml
@@ -1,6 +1,5 @@
 osDistro: ubuntu
 osVersion: bionic
-ec2User: ubuntu
 packages:
   - arch: amd64
     ami: ami-0263e4deb427da90e

--- a/versions/ubuntu_20_focal.yml
+++ b/versions/ubuntu_20_focal.yml
@@ -1,6 +1,5 @@
 osDistro: ubuntu
 osVersion: focal
-ec2User: ubuntu
 packages:
   - arch: amd64
     ami: ami-0c4f7023847b90238

--- a/versions/ubuntu_22_jammy.yml
+++ b/versions/ubuntu_22_jammy.yml
@@ -1,6 +1,5 @@
 osDistro: ubuntu
 osVersion: jammy
-ec2User: ubuntu
 packages:
   - arch: amd64
     ami: ami-00874d747dde814fa

--- a/versions/windows-server-2019.yml
+++ b/versions/windows-server-2019.yml
@@ -1,6 +1,5 @@
 osDistro: windows-server
 osVersion: 2019
-ec2User: Administrator
 packages:
   - arch: win64
     ami: ami-024614f01f42eeb66

--- a/versions/windows-server-2022.yml
+++ b/versions/windows-server-2022.yml
@@ -1,6 +1,5 @@
 osDistro: windows-server
 osVersion: 2022
-ec2User: Administrator
 packages:
   - arch: win64
     ami: ami-0c2b0d3fb02824d92


### PR DESCRIPTION
We are not using the ec2User attribute since we are using SSM to connect to the EC2 instances, so we can clean it up from the version files.