### PR TITLE
Spin up and tear down testing EC2 instances

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,8 +64,6 @@ jobs:
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
   # If these are not available, they are downloaded from the official Fluent Bit repository and repackaged to be used by the NRIA.
   download_official_packages:
-    # TODO Re-enable
-    if: false
     needs: [setup_environment]
     runs-on: ubuntu-latest
     strategy:
@@ -115,8 +113,6 @@ jobs:
           path: packages/${{ matrix.targetPackageName }}
 
   upload_official_packages_to_prerelease:
-    # TODO Re-enable
-    if: false
     needs: [ download_official_packages ]
     runs-on: ubuntu-latest
 
@@ -132,8 +128,6 @@ jobs:
           gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/* --repo newrelic/fluent-bit-package
 
   spin_up_suse:
-    # TODO Re-enable
-    if: false
     needs: setup_environment
     uses: ./.github/workflows/run_task.yml
     with:
@@ -141,8 +135,6 @@ jobs:
     secrets: inherit
 
   build_suse_packages:
-    # TODO Re-enable
-    if: false
     needs: spin_up_suse
     uses: ./.github/workflows/run_task.yml
     with:
@@ -150,8 +142,6 @@ jobs:
     secrets: inherit
 
   tear_down_suse:
-    # TODO Re-enable
-    if: false
     needs: build_suse_packages
     uses: ./.github/workflows/run_task.yml
     with:
@@ -159,8 +149,6 @@ jobs:
     secrets: inherit
 
   sign_suse_packages:
-    # TODO Re-enable
-    if: false
     needs: [setup_environment, build_suse_packages]
     runs-on: ubuntu-latest
     strategy:
@@ -189,9 +177,7 @@ jobs:
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:
-    # TODO Re-enable
-    needs: [ setup_environment ]
-    # needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
+    needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
     name: Run E2E tests
     uses: ./.github/workflows/run_e2e_tests.yml
     with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,6 +64,8 @@ jobs:
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
   # If these are not available, they are downloaded from the official Fluent Bit repository and repackaged to be used by the NRIA.
   download_official_packages:
+    # TODO Re-enable
+    if: false
     needs: [setup_environment]
     runs-on: ubuntu-latest
     strategy:
@@ -113,6 +115,8 @@ jobs:
           path: packages/${{ matrix.targetPackageName }}
 
   upload_official_packages_to_prerelease:
+    # TODO Re-enable
+    if: false
     needs: [ download_official_packages ]
     runs-on: ubuntu-latest
 
@@ -128,6 +132,8 @@ jobs:
           gh release upload ${{ env.PRE_RELEASE_NAME }} packages/*/* --repo newrelic/fluent-bit-package
 
   spin_up_suse:
+    # TODO Re-enable
+    if: false
     needs: setup_environment
     uses: ./.github/workflows/run_task.yml
     with:
@@ -135,6 +141,8 @@ jobs:
     secrets: inherit
 
   build_suse_packages:
+    # TODO Re-enable
+    if: false
     needs: spin_up_suse
     uses: ./.github/workflows/run_task.yml
     with:
@@ -142,6 +150,8 @@ jobs:
     secrets: inherit
 
   tear_down_suse:
+    # TODO Re-enable
+    if: false
     needs: build_suse_packages
     uses: ./.github/workflows/run_task.yml
     with:
@@ -149,6 +159,8 @@ jobs:
     secrets: inherit
 
   sign_suse_packages:
+    # TODO Re-enable
+    if: false
     needs: [setup_environment, build_suse_packages]
     runs-on: ubuntu-latest
     strategy:
@@ -177,7 +189,9 @@ jobs:
 
   # Runs E2E tests using the packages available in the tmp-pr-#PR prerelease
   run_e2e_tests:
-    needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
+    # TODO Re-enable
+    needs: [ setup_environment ]
+    # needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       gh_release_name: ${{ needs.setup_environment.outputs.pre_release_name }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -192,7 +192,9 @@ jobs:
     # TODO Re-enable
     needs: [ setup_environment ]
     # needs: [ setup_environment, sign_suse_packages, upload_official_packages_to_prerelease]
+    name: Run E2E tests
     uses: ./.github/workflows/run_e2e_tests.yml
     with:
       gh_release_name: ${{ needs.setup_environment.outputs.pre_release_name }}
       infra_agent_version: latest
+    secrets: inherit

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -35,13 +35,15 @@ on:
 concurrency: e2e-workflow-${{ inputs.gh_release_name }}
 
 jobs:
-  spin_up_test_runner_instances:
+  spin_up_test_executor_instances:
+    name: Spin up test executor instances
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "terraform TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
     secrets: inherit
 
-  tear_down_test_runner_instances:
+  tear_down_test_executor_instances:
+    name: Tear down test executor instances
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -42,8 +42,19 @@ jobs:
       container_make_target: "terraform TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
     secrets: inherit
 
+  provision_and_execute_tests:
+    name:
+    needs: [ spin_up_test_executor_instances ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Provision instances and run tests
+        run:
+          echo "TODO, stubbed step"
+
   tear_down_test_executor_instances:
     name: Tear down test executor instances
+    needs: [ provision_and_execute_tests ]
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -35,6 +35,18 @@ on:
 concurrency: e2e-workflow-${{ inputs.gh_release_name }}
 
 jobs:
+#  spin_up_test_runner_instances:
+#    uses: ./.github/workflows/run_task.yml
+#    with:
+#      container_make_target: "terraform TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
+#    secrets: inherit
+#
+#  tear_down_test_runner_instances:
+#    uses: ./.github/workflows/run_task.yml
+#    with:
+#      container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
+#    secrets: inherit
+
   e2e_tests:
     runs-on: ubuntu-latest
 
@@ -42,4 +54,4 @@ jobs:
       - name: Run E2E tests
         run: |
           # TODO
-          echo "TODO: Stubbed step. gh_release_name: ${{ inputs.gh_release_name }}, infra_agent_version: ${{ inputs.infra_agent_version }}"
+          echo "TODO: Stubbed step. gh_release_name: ${{ inputs.gh_release_name }}, infra_agent_version: ${{ inputs.infra_agent_version }}, PR_NUMBER=${{ github.event.pull_request.number }}"

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -35,23 +35,14 @@ on:
 concurrency: e2e-workflow-${{ inputs.gh_release_name }}
 
 jobs:
-#  spin_up_test_runner_instances:
-#    uses: ./.github/workflows/run_task.yml
-#    with:
-#      container_make_target: "terraform TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
-#    secrets: inherit
-#
-#  tear_down_test_runner_instances:
-#    uses: ./.github/workflows/run_task.yml
-#    with:
-#      container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
-#    secrets: inherit
+  spin_up_test_runner_instances:
+    uses: ./.github/workflows/run_task.yml
+    with:
+      container_make_target: "terraform TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
+    secrets: inherit
 
-  e2e_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Run E2E tests
-        run: |
-          # TODO
-          echo "TODO: Stubbed step. gh_release_name: ${{ inputs.gh_release_name }}, infra_agent_version: ${{ inputs.infra_agent_version }}, PR_NUMBER=${{ github.event.pull_request.number }}"
+  tear_down_test_runner_instances:
+    uses: ./.github/workflows/run_task.yml
+    with:
+      container_make_target: "terraform-clean TERRAFORM_PROJECT=ec2-test-executors PR_NUMBER=${{ github.event.pull_request.number }}"
+    secrets: inherit

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -15,16 +15,14 @@ locals {
   ec2_instance_profile = "logging-e2e-testing-ec2-ssm-instance-profile"
 
   # See: https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent-status-and-restart.html
-  # TODO Verify for Ubuntu: it seems Ubuntu >18 uses snap, but verify if systemctl also starts SSM agent correctly
-  linux_user_data_boot_script_for_ssm = <<EOF
-#!/bin/bash
-systemctl enable amazon-ssm-agent
-systemctl start amazon-ssm-agent
-EOF
-  # TODO Test
-  windows_data_boot_script_for_ssm = <<EOF
-Start-Service AmazonSSMAgent
-EOF
+
+  # Amazon Linux, Ubuntu and Windows come with the SSM Agent installed by default and is started on boot automatically.
+  # SLES AMIs come with the SSM Agent installed by default but it requires being started on boot.
+  # CentOS AMIs do not come with the SSM Agent installed by default: https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-centos-7.html
+  # Debian AMIs do not come with the SSM Agent installed by default: https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-deb.html
+  # The user data script referenced below takes care of installing the SSM Agent and starting it on boot for the aforementioned OSes.
+  os_distros_requiring_user_data_script_for_ssm = ["sles", "centos", "debian"]
+  user_data_script_for_ssm_path = "${path.module}/user_data_script_for_ssm.tftpl"
 
   # Default tags applied to all created resources
   default_tags = {
@@ -42,13 +40,13 @@ module "ec2_instance" {
   name = each.key
 
   ami                    = each.value.ami
-  instance_type          = "t3.small"
+  instance_type          = contains(["x86_64", "amd64", "win64", "win32"], each.value.arch) ? "t3.small" : "t4g.small"
   vpc_security_group_ids = [local.ec2_instances_security_group]
   subnet_id              = local.aws_vpc_subnet
 
   iam_instance_profile   = local.ec2_instance_profile
 
-  user_data = each.value.osDistro == "windows-server" ? local.windows_data_boot_script_for_ssm : local.linux_user_data_boot_script_for_ssm
+  user_data = contains(local.os_distros_requiring_user_data_script_for_ssm, each.value.osDistro) ? templatefile(local.user_data_script_for_ssm_path, { os_distro = each.value.osDistro, arch = each.value.arch, os_version = each.value.osVersion }) : null
 
   # Include fields from the strategy matrix into the EC2 instance tags. Thanks to this, we are able to know which Fluent
   # Bit version and for which OS version and arch is each EC2 instance meant to compile/test. This is later read in the

--- a/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
+++ b/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+%{if os_distro == "centos"}
+sudo %{if os_version == 7}yum%{else}dnf%{endif} install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_%{if arch == "x86_64"}amd64%{else}arm64%{endif}/amazon-ssm-agent.rpm
+%{endif}
+
+%{if os_distro == "debian"}
+mkdir -p /tmp/ssm
+cd /tmp/ssm
+wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${arch}/amazon-ssm-agent.deb
+sudo dpkg -i amazon-ssm-agent.deb
+%{endif}
+
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent

--- a/terraform/ec2-suse-builders/main.tf
+++ b/terraform/ec2-suse-builders/main.tf
@@ -2,7 +2,6 @@ locals {
   suse_matrix_path = "../../versions/slesMatrix.json"
 }
 
-
 module "suse-fb-builder-instances" {
   source = "../ec2-instances-creator"
 

--- a/terraform/ec2-test-executors/main.tf
+++ b/terraform/ec2-test-executors/main.tf
@@ -1,0 +1,11 @@
+locals {
+  all_instances_matrix_path = "../../versions/strategyMatrix.json"
+}
+
+module "test-executor-instances" {
+  source = "../ec2-instances-creator"
+
+  instance_matrix_file = local.all_instances_matrix_path
+  pr_number = var.pr_number
+  instance_type = "test-executor"
+}

--- a/terraform/ec2-test-executors/terraform.backend.tf.dist
+++ b/terraform/ec2-test-executors/terraform.backend.tf.dist
@@ -1,0 +1,11 @@
+#########################################
+# State Backend
+#########################################
+terraform {
+  backend "s3" {
+    encrypt = true
+    bucket  = "logging-e2e-testing-tf"
+    key     = "test-executors-pr-PR_NUMBER"
+    region  = "us-east-2"
+  }
+}

--- a/terraform/ec2-test-executors/variables.tf
+++ b/terraform/ec2-test-executors/variables.tf
@@ -1,0 +1,4 @@
+variable "pr_number" {
+  type = string
+  description = "Pull request number"
+}

--- a/versions/amazonlinux_2.yml
+++ b/versions/amazonlinux_2.yml
@@ -2,6 +2,6 @@ osDistro: amazonlinux
 osVersion: 2
 packages:
   - arch: x86_64
-    ami: ami-0dfcb1ef8550277af
+    ami: ami-05e1405c57ab23683
   - arch: aarch64
-    ami: ami-0cd7323ab3e63805f
+    ami: ami-08d8cbe09f0a01184

--- a/versions/amazonlinux_2022.yml
+++ b/versions/amazonlinux_2022.yml
@@ -1,5 +1,0 @@
-osDistro: amazonlinux
-osVersion: 2022
-packages:
-  - arch: x86_64
-    ami: ami-0ae4f98256391dad0

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,0 +1,7 @@
+osDistro: amazonlinux
+osVersion: 2023
+packages:
+  - arch: x86_64
+    ami: ami-01103fb68b3569475
+  - arch: aarch64
+    ami: ami-01416d11f88e7cb55

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,5 +1,7 @@
 osDistro: amazonlinux
 osVersion: 2023
+# First available AL2023 version with both x86_64 and aarch64 support is 2.1.5
+fbVersion: 2.1.9
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475

--- a/versions/centos_7.yml
+++ b/versions/centos_7.yml
@@ -2,6 +2,6 @@ osDistro: centos
 osVersion: 7
 packages:
   - arch: x86_64
-    ami: ami-02358d9f5245918a3
+    ami: ami-05a36e1502605b4aa
   - arch: aarch64
-    ami: ami-0144a5a84f5699847
+    ami: ami-01f5164ccc6a81e61

--- a/versions/centos_8.yml
+++ b/versions/centos_8.yml
@@ -2,6 +2,6 @@ osDistro: centos
 osVersion: 8
 packages:
   - arch: x86_64
-    ami: ami-0c07df890a618c98a
+    ami: ami-0af29b92a1457bf87
   - arch: aarch64
-    ami: ami-09243ba0df36156d9
+    ami: ami-0dce27ea07b1afb8f

--- a/versions/centos_9.yml
+++ b/versions/centos_9.yml
@@ -2,6 +2,6 @@ osDistro: centos
 osVersion: 9
 packages:
   - arch: x86_64
-    ami: ami-08c92aec9ccf0e1e9
+    ami: ami-011d59a275b482a49
   - arch: aarch64
-    ami: ami-0c92309a18dff3e71
+    ami: ami-008dee3b597bad5c2

--- a/versions/debian_10_buster.yml
+++ b/versions/debian_10_buster.yml
@@ -2,6 +2,6 @@ osDistro: debian
 osVersion: buster
 packages:
   - arch: amd64
-    ami: ami-07d02ee1eeb0c996c
+    ami: ami-05bf29fabdee3e5d2
   - arch: arm64
-    ami: ami-08b2293fdd2deba2a
+    ami: ami-03e6e856fa72db174

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -2,6 +2,6 @@ osDistro: debian
 osVersion: bullseye
 packages:
   - arch: amd64
-    ami: ami-052465340e6b59fc0
+    ami: ami-06a7641d5bd7bdc65
   - arch: arm64
-    ami: ami-0ffd2fd6f1a81e491
+    ami: ami-0237d8bf4f989d904

--- a/versions/debian_12_bookworm.yml
+++ b/versions/debian_12_bookworm.yml
@@ -2,6 +2,6 @@ osDistro: debian
 osVersion: bookworm
 packages:
   - arch: amd64
-    ami: ami-08ca7cb88210133e5
+    ami: ami-0ddf7dfd13a83d8c8
   - arch: arm64
-    ami: ami-0efa233eb46a48f36
+    ami: ami-0edd7fb88540aa37c

--- a/versions/strategyMatrix.py
+++ b/versions/strategyMatrix.py
@@ -75,7 +75,7 @@ def rpm_package_details(pkg):
     rpm_target_arch_remap = {'aarch64': 'arm64', 'x86_64': 'x86_64'}
     rpm_os_family_remap = {'amazonlinux': 'amazonlinux', 'centos': 'el'}
     return {
-        'packageUrl': f"https://packages.fluentbit.io/{pkg['osDistro']}/{pkg['osVersion']}/{pkg['arch']}/fluent-bit-{pkg['fbVersion']}-1.{pkg['arch']}.rpm",
+        'packageUrl': f"https://packages.fluentbit.io/{pkg['osDistro']}/{pkg['osVersion']}/fluent-bit-{pkg['fbVersion']}-1.{pkg['arch']}.rpm",
         'targetPackageName': f"fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}-{pkg['osVersion']}.{rpm_target_arch_remap[pkg['arch']]}.rpm",
         'nrPackageUrl': 
 f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/{rpm_os_family_remap[pkg['osDistro']]}/{pkg['osVersion']}/{pkg['arch']}/fluent-bit-{pkg['fbVersion']}-1.{pkg['osDistro']}-{pkg['osVersion']}.{rpm_target_arch_remap[pkg['arch']]}.rpm"

--- a/versions/ubuntu_18_bionic.yml
+++ b/versions/ubuntu_18_bionic.yml
@@ -2,6 +2,6 @@ osDistro: ubuntu
 osVersion: bionic
 packages:
   - arch: amd64
-    ami: ami-0263e4deb427da90e
+    ami: ami-04c8fda7dfbb7604a
   - arch: arm64
-    ami: ami-0a5ec5786500eaf19
+    ami: ami-0d8ade5793886b541

--- a/versions/ubuntu_20_focal.yml
+++ b/versions/ubuntu_20_focal.yml
@@ -2,6 +2,6 @@ osDistro: ubuntu
 osVersion: focal
 packages:
   - arch: amd64
-    ami: ami-0c4f7023847b90238
+    ami: ami-0fbe25808b51a1ac4
   - arch: arm64
-    ami: ami-0d70a59d7191a8079
+    ami: ami-0a60c2b5a4afb1607

--- a/versions/ubuntu_22_jammy.yml
+++ b/versions/ubuntu_22_jammy.yml
@@ -2,6 +2,6 @@ osDistro: ubuntu
 osVersion: jammy
 packages:
   - arch: amd64
-    ami: ami-00874d747dde814fa
+    ami: ami-03a03b8680a3d588e
   - arch: arm64
-    ami: ami-0a84a722790d914a9
+    ami: ami-0058b7812506d8659

--- a/versions/windows-server-2019.yml
+++ b/versions/windows-server-2019.yml
@@ -2,6 +2,7 @@ osDistro: windows-server
 osVersion: 2019
 packages:
   - arch: win64
-    ami: ami-024614f01f42eeb66
+    ami: ami-0d1435d1563c37bbd
+  # There is no win32 image available in AWS, so we use the w64 one to test the w32 binaries
   - arch: win32
-    ami: ami-024614f01f42eeb66
+    ami: ami-0d1435d1563c37bbd

--- a/versions/windows-server-2022.yml
+++ b/versions/windows-server-2022.yml
@@ -2,6 +2,6 @@ osDistro: windows-server
 osVersion: 2022
 packages:
   - arch: win64
-    ami: ami-0c2b0d3fb02824d92
+    ami: ami-030885cc0ec082d8d
   - arch: win32
-    ami: ami-0c2b0d3fb02824d92
+    ami: ami-030885cc0ec082d8d


### PR DESCRIPTION
This PR creates and destroys the test executor VMs during the "Run E2E tests" workflow.
- All the VMs have been (manually) tested to be SSM-accessible once created (this will be properly tested in the next PR, where we'll be managing them with Ansible).
- CentOS 8 and 9 images use CentOS Stream, while CentOS 7 keeps using CentOS.
- All the AMIs have been adapted for the ones in the `us-east-2` region.