### PR TITLE
Provisions Linux test executing instances

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,7 +46,8 @@ jobs:
           pre_release_notes="Created by PR: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
 
           echo "Creating pre-release: $pre_release_tag"
-          gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes"
+          # We need the pre-release to NOT be a draft, otherwise it won't be visible to download packages from the Ansible-managed hosts
+          gh release create "$pre_release_tag" --prerelease --title "$pre_release_title" --notes "$pre_release_notes --draft false
 
       - name: Install python
         uses: actions/setup-python@v4

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,6 +3,8 @@ The "local" make target allows you to test any make target like you were executi
 though, it will execute it in a local Docker container using the same image used by the Fargate task and by mounting this
 repository (in its current status, locally) as a volume instead of pulling it from GitHub.
 
+The target will read some of the required credentials from Vault. So, **you need to log in to Vault before using this make target.**
+
 This target accepts a single argument, named "target", which specifies what target needs to be executed inside the container,
 as well as its arguments. Note that **the PR_NUMBER environment variable does NOT need to be provided**. Instead, the "local"
 make target will set it up for you to the value `local-<YOUR_USERNAME>`.

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ local:
 		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 		-e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
 		-e AWS_DEFAULT_REGION=us-east-2 \
+		-e NEW_RELIC_API_KEY=$(shell newrelic-vault us read -field=value terraform/logging/logging-e2e-testing-infra/NEW_RELIC_API_KEY) \
+		-e NEW_RELIC_ACCOUNT_ID=$(shell newrelic-vault us read -field=value terraform/logging/logging-e2e-testing-infra/NEW_RELIC_ACCOUNT_ID) \
+		-e NEW_RELIC_REGION=$(shell newrelic-vault us read -field=value terraform/logging/logging-e2e-testing-infra/NEW_RELIC_REGION) \
 		ghcr.io/newrelic/fargate-runner-action:latest \
 		$(target) PR_NUMBER=local-$(USER)
 

--- a/ansible/build-fb-suse/playbook-localhost.yml.dist
+++ b/ansible/build-fb-suse/playbook-localhost.yml.dist
@@ -15,3 +15,4 @@
     - name: Upload generated artifacts to release
       command: "gh release upload tmp-pr-{{ pr_number }} {{ item.path }}"
       loop: "{{ directory_contents.files }}"
+      when: pr_number is not regex('^local-.*')

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -25,9 +25,6 @@
     arch: "{{ tags.arch }}"
     fluent_bit_package_name: "fluent-bit-{{ fluent_bit_version }}-1.{{ os_distro }}{{ os_version }}.{{ arch }}.rpm"
   tasks:
-    - name: Wait for connection to be available
-      wait_for_connection:
-
     - name: Install dependencies
       community.general.zypper:
         name: "{{ item }}"
@@ -48,9 +45,9 @@
       become: true
       register: install_status
       until: install_status is success
-      # Retry up to 2.5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
+      # Retry up to 5 minutes, because at startup the zypper command might temporarily hold a lock that prevents installing packages
       delay: 15
-      retries: 10
+      retries: 20
 
     - name: Download and extract Bison {{ bison_version }}
       unarchive:

--- a/ansible/provision-and-execute-tests/Makefile
+++ b/ansible/provision-and-execute-tests/Makefile
@@ -1,0 +1,10 @@
+include ../Ansible.common.mk
+
+.DEFAULT_GOAL := provision-and-execute-tests
+
+.PHONY: provision-and-execute-tests
+provision-and-execute-tests: ansible/dependencies ansible/prepare-inventory
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
+
+.PHONY: clean
+clean: ansible/clean

--- a/ansible/provision-and-execute-tests/ansible.cfg
+++ b/ansible/provision-and-execute-tests/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+# To avoid Ansible printing warnings such as:
+# [WARNING]: Platform linux on host ... is using the discovered Python interpreter at /usr/libexec/platform-python, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
+#  core/2.15/reference_appendices/interpreter_discovery.html for more information.
+interpreter_python = auto_silent

--- a/ansible/provision-and-execute-tests/aws_ec2.yml.dist
+++ b/ansible/provision-and-execute-tests/aws_ec2.yml.dist
@@ -1,0 +1,31 @@
+# Configuration reference:
+# - https://docs.ansible.com/ansible/latest/collections/amazon/aws/docsite/aws_ec2_guide.html
+# - https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html
+# - https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html
+
+plugin: aws_ec2
+regions:
+    - us-east-2
+hostnames:
+    # This is how each host will be displayed when executing the Ansible playbook.
+    - tag:Name
+filters:
+    # Select instances to run this playbook on
+    tag:pr_number: PR_NUMBER
+    tag:instance_type: test-executor
+groups:
+    suse_12: "tags.os_version.startswith('12')"
+    suse_15: "tags.os_version.startswith('15')"
+    windows: "'windows-server' in tags.os_distro"
+    linux: "'windows-server' not in tags.os_distro"
+compose:
+    # This is how the Ansible SSM plugin will connect to each host. We cannot use the hostname (tag:Name) directly because
+    # it contains "." characters, which are not allowed by the SSM plugin.
+    ansible_host: instance_id
+    # Host variables that are strings (not variables) need to be wrapped with two sets of quotes.
+    # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
+    ansible_connection: '"community.aws.aws_ssm"'
+    ansible_aws_ssm_bucket_name: '"logging-e2e-testing-ssm-transfers"'
+    ansible_aws_ssm_bucket_sse_mode: '"AES256"'
+    ansible_aws_ssm_region: '"us-east-2"'
+    pr_number: '"PR_NUMBER"'

--- a/ansible/provision-and-execute-tests/group_vars/suse_12.yml
+++ b/ansible/provision-and-execute-tests/group_vars/suse_12.yml
@@ -1,0 +1,6 @@
+# SUSE 12 contains Python 2.7 and 3.4. Ansible requires a minimum of Python 2.7 or 3.5 to work.
+# Due to this issue (https://github.com/ansible/ansible/issues/77840#issuecomment-1252321964),
+# it tries Python 3 only, and when gathering the facts from the remote SUSE server it
+# discovers it is running a too old Python 3 (3.4 < 3.5) version. We need to instruct it to
+# explicitly use Python 2.7 for it to work.
+ansible_python_interpreter: /usr/bin/python

--- a/ansible/provision-and-execute-tests/group_vars/suse_15.yml
+++ b/ansible/provision-and-execute-tests/group_vars/suse_15.yml
@@ -1,0 +1,1 @@
+ansible_python_interpreter: /usr/bin/python3

--- a/ansible/provision-and-execute-tests/group_vars/windows.yml
+++ b/ansible/provision-and-execute-tests/group_vars/windows.yml
@@ -1,0 +1,1 @@
+ansible_shell_type: powershell

--- a/ansible/provision-and-execute-tests/playbook.yml
+++ b/ansible/provision-and-execute-tests/playbook.yml
@@ -1,0 +1,58 @@
+
+- name: Provision test executor instances and execute tests
+  hosts: linux
+  vars:
+    node_version: 16.3.0
+
+    # The following information is populated using the gathered inventory variables
+    fluent_bit_package_name: "{{ tags.fb_package_name }}"
+    pr_number: "{{ tags.pr_number }}"
+  environment:
+    NEW_RELIC_API_KEY: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_API_KEY') }}"
+    NEW_RELIC_ACCOUNT_ID: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_ACCOUNT_ID') }}"
+    NEW_RELIC_REGION: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_REGION') }}"
+  tasks:
+    - name: Install Infrastructure Agent
+      ansible.builtin.include_role:
+        name: newrelic.newrelic_install
+        # Despite being the default, I want to emphasize that we do NOT want the role variables to be
+        # exposed to the play. Otherwise, the "tags" variable specified below would overwrite the AWS "tags"
+        # variable object (that comes from the inventory), which would cause that the `fluent_bit_package_name`
+        # (or any variable depending on the AWS tags) would not be resolvable. Note that this option is only
+        # available in "include_role", and not in "import_role".
+        public: false
+      vars:
+        targets:
+          - infrastructure
+        tags:
+          product: logging
+          owning_team: logging
+          project: fluent-bit-packaging-and-testing
+
+    - name: Configure log forwarding
+      ansible.builtin.include_role:
+        name: create_logging_configs
+      vars:
+        monitored_file: /path/to/file.log
+        monitored_syslog_rfc_5424_tcp_port: 1234
+        monitored_syslog_rfc_5424_udp_port: 5678
+        monitored_tcp_port: 9012
+        monitored_systemd_unit: logtar
+
+    - name: Install Fluent Bit package to be tested for this distro
+      ansible.builtin.include_role:
+        name: install_fluent_bit_from_gh_prerelease
+      vars:
+        fb_package_name: "{{ fluent_bit_package_name }}"
+        gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
+
+    - name: Set up Node and run tests
+      ansible.builtin.include_role:
+        role: morgangraphics.ansible_role_nvm
+      vars:
+        nodejs_version: "{{ node_version }}"
+        # CentOS comes without "wget", so using "curl" instead
+        nvm_install: "curl"
+        nvm_commands:
+          - "npm -v"
+          - "node -v"

--- a/ansible/provision-and-execute-tests/playbook.yml
+++ b/ansible/provision-and-execute-tests/playbook.yml
@@ -45,6 +45,7 @@
       vars:
         fb_package_name: "{{ fluent_bit_package_name }}"
         gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
+      when: pr_number is not regex('^local-.*')
 
     - name: Set up Node and run tests
       ansible.builtin.include_role:

--- a/ansible/provision-and-execute-tests/requirements.yml
+++ b/ansible/provision-and-execute-tests/requirements.yml
@@ -1,0 +1,14 @@
+collections:
+  - name: community.aws
+    # Fixes https://github.com/ansible-collections/community.aws/pull/558
+    version: 6.3.0
+  - name: ansible.windows
+    version: 1.14.0
+  - name: ansible.utils
+    version: 2.11.0
+
+roles:
+  - name: morgangraphics.ansible_role_nvm
+    version: v1.5.2
+  - name: newrelic.newrelic_install
+    version: v0.6.0

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/README.md
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/README.md
@@ -1,0 +1,35 @@
+Role Name
+=========
+
+This role creates the necessary YML files under the `logging.d` directory of the Infrastructure Agent. This will result in
+the Infrastructure Agent to pick them up and translate them into native Fluent Bit configurations and restart Fluent Bit
+to listen on the required inputs. The integration test suite will then stress each of these inputs to validate that logs 
+can be correctly captured and stored in New Relic.
+
+Role Variables
+--------------
+
+The role requires the following variables:
+- `monitored_file` (Linux, Windows): File to be tailed from
+- `monitored_syslog_rfc_5424_tcp_port` (Linux): TCP port to listen to for Syslog RFC5424 formatted payloads
+- `monitored_syslog_rfc_5424_udp_port` (Linux): UDP port to listen to for Syslog RFC5424 formatted payloads
+- `monitored_tcp_port` (Linux, Windows): TCP port to listen to for unformatted (plain text) payloads separated by newline (\n) characters
+- `monitored_systemd_unit` (Linux): Systemd unit to capture logs from
+- `monitored_windows_log_name_using_winlog` (Windows): Windows Event Log channel to read logs from using the Fluent Bit `winlog` plugin (uses the old Windows Event Log API)
+- `monitored_windows_log_name_using_winevtlog` (Windows): Windows Event Log channel to read logs from using the Fluent Bit `winevtlog` plugin (uses the new Windows Event Log API `winevt.h`)
+
+
+Example Playbook
+----------------
+
+Example usage:
+
+    - name: Configure log forwarding
+      ansible.builtin.include_role:
+        name: create_logging_configs
+      vars:
+        monitored_file: /path/to/file.log
+        monitored_syslog_rfc_5424_tcp_port: 1234
+        monitored_syslog_rfc_5424_udp_port: 5678
+        monitored_tcp_port: 9012
+        monitored_systemd_unit: logtar

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/linux.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/linux.yml
@@ -1,0 +1,25 @@
+- name: Check mandatory variables
+  assert:
+    that:
+      - monitored_file is defined
+      - monitored_syslog_rfc_5424_tcp_port is defined
+      - monitored_syslog_rfc_5424_udp_port is defined
+      - monitored_tcp_port is defined
+      - monitored_systemd_unit is defined
+
+- name: Create configuration directory
+  ansible.builtin.file:
+    path: "{{ logging_d_config_path }}"
+    state: directory
+  become: true
+
+- name: Configure log forwarding from {{ item }}
+  template:
+    src: "{{ item }}.yml.j2"
+    dest: "{{ logging_d_config_path }}/{{ item }}.yml"
+  become: true
+  loop:
+    - file
+    - syslog
+    - systemd
+    - tcp

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/main.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Configure YML files in logging.d folder (Linux)
+  include_tasks: linux.yml
+  when: ansible_system == 'Linux'
+
+- name: Configure YML files in logging.d folder (Windows)
+  include_tasks: windows.yml
+  when: ansible_system != 'Linux'

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/windows.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/windows.yml
@@ -1,0 +1,25 @@
+- name: Check mandatory variables
+  assert:
+    that:
+      - monitored_file is defined
+      - monitored_tcp_port is defined
+      - monitored_windows_log_name_using_winlog is defined
+      - monitored_windows_log_name_using_winevtlog is defined
+
+# TODO The following is still a draft and needs to be tested
+
+- name: Create configuration directory
+  ansible.windows.win_file:
+    path: "{{ logging_d_config_path }}"
+    state: directory
+
+- name: Configure log forwarding from {{ item }}
+  win_template:
+    src: "{{ item }}.yml.j2"
+    dest: "{{ logging_d_config_path }}/{{ item }}.yml"
+  become: true
+  loop:
+    - file
+    - tcp
+    - winlog
+    - winevtlog

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/file.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/file.yml.j2
@@ -1,0 +1,3 @@
+logs:
+  - name: file-test
+    file: {{ monitored_file }}

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/syslog.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/syslog.yml.j2
@@ -1,0 +1,9 @@
+logs:
+  - name: syslog-tcp-test
+    syslog:
+      uri: tcp://127.0.0.1:{{ monitored_syslog_rfc_5424_tcp_port }}
+      parser: rfc5424
+  - name: syslog-udp-test
+    syslog:
+      uri: tcp://127.0.0.1:{{ monitored_syslog_rfc_5424_udp_port }}
+      parser: rfc5424

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/systemd.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/systemd.yml.j2
@@ -1,0 +1,3 @@
+logs:
+  - name: systemd-test
+    systemd: {{ monitored_systemd_unit }}

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/tcp.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/tcp.yml.j2
@@ -1,0 +1,7 @@
+logs:
+  - name: tcp-test
+      tcp:
+        uri: tcp://0.0.0.0:{{ monitored_tcp_port }}
+        format: none
+        separator: \n
+      max_line_kb: 32

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/winevtlog.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/winevtlog.yml.j2
@@ -1,0 +1,4 @@
+logs:
+  - name: winevtlog-test
+    winevtlog:
+      channel: {{ monitored_windows_log_name_using_winevtlog }}

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/winlog.yml.j2
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/templates/winlog.yml.j2
@@ -1,0 +1,4 @@
+logs:
+  - name: winlog-test
+    winlog:
+      channel: {{ monitored_windows_log_name_using_winlog }}

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/vars/main.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/vars/main.yml
@@ -1,0 +1,1 @@
+logging_d_config_path: "{{ '/etc/newrelic-infra/logging.d' if ansible_system == 'Linux' else 'TODO' }}"

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/README.md
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/README.md
@@ -1,0 +1,25 @@
+Role Name
+=========
+
+This role uninstalls the existing Fluent Bit package and re-installs by grabbing it from the specified GH prerelease. It
+also takes care of restarting the Infra-Agent to ensure that it picks up the new Fluent Bit binary.
+
+Role Variables
+--------------
+
+The role requires the following variables:
+- `gh_prerelease_tag`: The name of the GH release from [fluent-bit-package](https://github.com/newrelic/fluent-bit-package) to download the Fluent Bit package from.
+- `fb_package_name`: The Fluent Bit package name to download from the GH prerelease.
+
+
+Example Playbook
+----------------
+
+Example usage:
+
+    - name: Install Fluent Bit package to be tested for this distro
+      ansible.builtin.include_role:
+        name: install_fluent_bit_from_gh_prerelease
+      vars:
+        gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
+        fb_package_name: "package-name" # This is typically provided as a tag in the EC2 instance

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/apt.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/apt.yml
@@ -1,0 +1,7 @@
+- name: Install Fluent Bit package from URL
+  ansible.builtin.apt:
+    deb: "{{ fb_package_url }}"
+    # We want our package to overwrite the one that comes with the Infra Agent, even if it implies downgrading it
+    allow_downgrade: true
+    state: present
+  become: true

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/dnf.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/dnf.yml
@@ -1,0 +1,7 @@
+- name: Install Fluent Bit package
+  ansible.builtin.dnf:
+    name: "{{ fb_package_url }}"
+    # We want our package to overwrite the one that comes with the Infra Agent, even if it implies downgrading it
+    allow_downgrade: true
+    state: present
+  become: true

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/main.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Check mandatory variables
+  assert:
+    that:
+      - gh_prerelease_tag is defined
+      - fb_package_name is defined
+
+- name: Install (replace) Fluent Bit package
+  include_tasks: "{{ ansible_pkg_mgr }}.yml"
+
+- name: Restart newrelic-infra service to pick up new Fluent Bit binary
+  ansible.builtin.service:
+    name: newrelic-infra
+    state: restarted
+  become: true

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/yum.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/yum.yml
@@ -1,0 +1,7 @@
+- name: Install Fluent Bit package
+  ansible.builtin.yum:
+    name: "{{ fb_package_url }}"
+    # We want our package to overwrite the one that comes with the Infra Agent, even if it implies downgrading it
+    allow_downgrade: true
+    state: present
+  become: true

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/zypper.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/zypper.yml
@@ -1,0 +1,7 @@
+- name: Install Fluent Bit package
+  community.general.zypper:
+    name: "{{ fb_package_url }}"
+    # We want our package to overwrite the one that comes with the Infra Agent, even if it implies downgrading it
+    oldpackage: true
+    state: present
+  become: true

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/vars/main.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/vars/main.yml
@@ -1,0 +1,1 @@
+fb_package_url: "https://github.com/newrelic/fluent-bit-package/releases/download/{{ gh_prerelease_tag }}/{{ fb_package_name }}"

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -6,6 +6,7 @@ locals {
   #    "osVersion": 9,
   #    "arch": "x86_64",
   #    "ami": "ami-08c92aec9ccf0e1e9",
+  #    "targetPackageName": "fluent-bit-2.0.7-1.centos-9.x86_64.rpm",
   #    ...
   #  }
   instance_matrix = jsondecode(file(var.instance_matrix_file))
@@ -58,6 +59,7 @@ module "ec2_instance" {
     arch = each.value.arch
     fb_version = each.value.fbVersion
     instance_type = var.instance_type
+    fb_package_name = each.value.targetPackageName
   })
 
   volume_tags = merge(local.default_tags, {
@@ -67,5 +69,6 @@ module "ec2_instance" {
     arch = each.value.arch
     fb_version = each.value.fbVersion
     instance_type = var.instance_type
+    fb_package_name = each.value.targetPackageName
   })
 }

--- a/versions/amazonlinux_2023.yml.disabled
+++ b/versions/amazonlinux_2023.yml.disabled
@@ -1,3 +1,5 @@
+# We need to temporally exclude Amazon Linux 2023 due to a bug (https://github.com/ansible-collections/community.aws/issues/1756)
+# that will be fixed here: https://github.com/ansible-collections/community.aws/pull/1839
 osDistro: amazonlinux
 osVersion: 2023
 # First available AL2023 version with both x86_64 and aarch64 support is 2.1.5


### PR DESCRIPTION
# Description
This PR performs the provisioning of the test executing VM instances by installing the Infrastructure Agent (in its latest released version), Fluent Bit (with the version pinned for each OS distro/version and arch) and NodeJS (will be used to execute the test suite later). The corresponding provisioning of Windows VMs will be done in a separate PR.

I will provide some explanatory comments to ease the PR review.

# Testing
The PR has been tested locally by using the "make local" target and running the Ansible playbooks against real EC2 instances.