### PR TITLE
Provision Windows test executing VMs

### DIFF
--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -25,6 +25,9 @@
     arch: "{{ tags.arch }}"
     fluent_bit_package_name: "fluent-bit-{{ fluent_bit_version }}-1.{{ os_distro }}{{ os_version }}.{{ arch }}.rpm"
   tasks:
+    - name: Wait for connection to be available
+      wait_for_connection:
+
     - name: Install dependencies
       community.general.zypper:
         name: "{{ item }}"

--- a/ansible/provision-and-execute-tests/playbook.yml
+++ b/ansible/provision-and-execute-tests/playbook.yml
@@ -1,5 +1,5 @@
 
-- name: Provision test executor instances and execute tests
+- name: Provision Linux test executor instances and execute tests
   hosts: linux
   vars:
     node_version: 16.3.0
@@ -12,6 +12,9 @@
     NEW_RELIC_ACCOUNT_ID: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_ACCOUNT_ID') }}"
     NEW_RELIC_REGION: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_REGION') }}"
   tasks:
+    - name: Wait for connection to be available
+      wait_for_connection:
+
     - name: Install Infrastructure Agent
       ansible.builtin.include_role:
         name: newrelic.newrelic_install
@@ -47,7 +50,7 @@
         gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
       when: pr_number is not regex('^local-.*')
 
-    - name: Set up Node and run tests
+    - name: Set up Node.js and run tests
       ansible.builtin.include_role:
         role: morgangraphics.ansible_role_nvm
       vars:
@@ -57,3 +60,80 @@
         nvm_commands:
           - "npm -v"
           - "node -v"
+
+- name: Provision Windows test executor instances and execute tests
+  hosts: windows
+  vars:
+    node_version: 16.3.0
+
+    # The following information is populated using the gathered inventory variables
+    fluent_bit_package_name: "{{ tags.fb_package_name }}"
+    pr_number: "{{ tags.pr_number }}"
+  environment:
+    NEW_RELIC_API_KEY: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_API_KEY') }}"
+    NEW_RELIC_ACCOUNT_ID: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_ACCOUNT_ID') }}"
+    NEW_RELIC_REGION: "{{ lookup('ansible.builtin.env', 'NEW_RELIC_REGION') }}"
+  tasks:
+    - name: Wait for connection to be available
+      wait_for_connection:
+
+    - name: Install Infrastructure Agent
+      ansible.builtin.include_role:
+        name: newrelic.newrelic_install
+        # Despite being the default, I want to emphasize that we do NOT want the role variables to be
+        # exposed to the play. Otherwise, the "tags" variable specified below would overwrite the AWS "tags"
+        # variable object (that comes from the inventory), which would cause that the `fluent_bit_package_name`
+        # (or any variable depending on the AWS tags) would not be resolvable. Note that this option is only
+        # available in "include_role", and not in "import_role".
+        public: false
+      vars:
+        targets:
+          - infrastructure
+        tags:
+          product: logging
+          owning_team: logging
+          project: fluent-bit-packaging-and-testing
+
+    - name: Configure log forwarding
+      ansible.builtin.include_role:
+        name: create_logging_configs
+      vars:
+        monitored_file: /path/to/file.log
+        monitored_tcp_port: 9012
+        monitored_windows_log_name_using_winlog: logtar_channel
+        monitored_windows_log_name_using_winevtlog: logtar_channel
+
+    - name: Install Fluent Bit package to be tested for this distro
+      ansible.builtin.include_role:
+        name: install_fluent_bit_from_gh_prerelease
+      vars:
+        fb_package_name: "{{ fluent_bit_package_name }}"
+        gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
+
+    - name: Install NVM
+      win_chocolatey:
+        name: nvm
+        state: present
+
+    # Ref: https://github.com/chocolatey/chocolatey-ansible/issues/22#issuecomment-680105708
+    - name: Reboot the machine so Chocolatey path will be picked up
+      ansible.windows.win_reboot:
+
+    - name: Install Node JS
+      ansible.windows.win_command: "nvm install {{ node_version }}"
+
+    - name: Run NPM version
+      ansible.windows.win_shell: "nvm use {{ node_version }} ; npm -v"
+      register: npm_version_out
+
+    - name: NPM version result (to be removed)
+      debug:
+        var: npm_version_out
+
+    - name: Run Node version
+      ansible.windows.win_shell: "nvm use {{ node_version }} ; node -v"
+      register: node_version_out
+
+    - name: Node version result (to be removed)
+      debug:
+        var: node_version_out

--- a/ansible/provision-and-execute-tests/playbook.yml
+++ b/ansible/provision-and-execute-tests/playbook.yml
@@ -109,6 +109,7 @@
       vars:
         fb_package_name: "{{ fluent_bit_package_name }}"
         gh_prerelease_tag: "tmp-pr-{{ pr_number }}"
+      when: pr_number is not regex('^local-.*')
 
     - name: Install NVM
       win_chocolatey:

--- a/ansible/provision-and-execute-tests/requirements.yml
+++ b/ansible/provision-and-execute-tests/requirements.yml
@@ -6,6 +6,8 @@ collections:
     version: 1.14.0
   - name: ansible.utils
     version: 2.11.0
+  - name: chocolatey.chocolatey
+    version: 1.5.1
 
 roles:
   - name: morgangraphics.ansible_role_nvm

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/windows.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/tasks/windows.yml
@@ -16,8 +16,7 @@
 - name: Configure log forwarding from {{ item }}
   win_template:
     src: "{{ item }}.yml.j2"
-    dest: "{{ logging_d_config_path }}/{{ item }}.yml"
-  become: true
+    dest: '{{ logging_d_config_path }}\{{ item }}.yml'
   loop:
     - file
     - tcp

--- a/ansible/provision-and-execute-tests/roles/create_logging_configs/vars/main.yml
+++ b/ansible/provision-and-execute-tests/roles/create_logging_configs/vars/main.yml
@@ -1,1 +1,1 @@
-logging_d_config_path: "{{ '/etc/newrelic-infra/logging.d' if ansible_system == 'Linux' else 'TODO' }}"
+logging_d_config_path: '{{ "/etc/newrelic-infra/logging.d" if ansible_system == "Linux" else "C:\\Program Files\\New Relic\\newrelic-infra\\logging.d\\" }}'

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/main.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/main.yml
@@ -1,15 +1,27 @@
 ---
-- name: Check mandatory variables
+- name: Check mandatory variables (all distros)
   assert:
     that:
       - gh_prerelease_tag is defined
       - fb_package_name is defined
 
-- name: Install (replace) Fluent Bit package
+- name: Install (replace) Fluent Bit Linux package
   include_tasks: "{{ ansible_pkg_mgr }}.yml"
+  when: ansible_system == 'Linux'
 
-- name: Restart newrelic-infra service to pick up new Fluent Bit binary
+- name: Install (replace) Fluent Bit Windows package
+  include_tasks: "windows.yml"
+  when: ansible_system != 'Linux'
+
+- name: Restart newrelic-infra service to pick up new Fluent Bit binary (Linux)
   ansible.builtin.service:
     name: newrelic-infra
     state: restarted
   become: true
+  when: ansible_system == 'Linux'
+
+- name: Restart newrelic-infra service to pick up new Fluent Bit binary (Windows)
+  ansible.windows.win_service:
+    name: newrelic-infra
+    state: restarted
+  when: ansible_system != 'Linux'

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/windows.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/windows.yml
@@ -8,6 +8,8 @@
     src: 'C:\Windows\Temp\{{ fb_package_name }}'
     dest: '{{ fb_windows_binary_path }}'
 
+# As of: https://github.com/newrelic/infrastructure-agent/blob/1.47.2/pkg/config/config.go#L899-L903
 - name: Modify Infrastructure Agent config to point to installed Fluent Bit executable
-  debug:
-    msg: "IMPLEMENT ME {{ fb_windows_binary_path }}!"
+  community.windows.win_lineinfile:
+    path: C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml
+    line: 'fluent_bit_exe_path: {{ fb_windows_binary_path }}\fluent-bit.exe'

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/windows.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/windows.yml
@@ -1,0 +1,13 @@
+- name: Download package from URL
+  win_get_url:
+    url: "{{ fb_package_url }}"
+    dest: C:\Windows\Temp
+
+- name: Unzip the Fluent Bit package
+  community.windows.win_unzip:
+    src: 'C:\Windows\Temp\{{ fb_package_name }}'
+    dest: '{{ fb_windows_binary_path }}'
+
+- name: Modify Infrastructure Agent config to point to installed Fluent Bit executable
+  debug:
+    msg: "IMPLEMENT ME {{ fb_windows_binary_path }}!"

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/vars/main.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/vars/main.yml
@@ -1,1 +1,2 @@
 fb_package_url: "https://github.com/newrelic/fluent-bit-package/releases/download/{{ gh_prerelease_tag }}/{{ fb_package_name }}"
+fb_windows_binary_path: C:\Applications\FluentBit


### PR DESCRIPTION
## Description
This PR performs the provisioning of the test executing **Windows** VM instances by installing the Infrastructure Agent (in its latest released version), Fluent Bit (with the version pinned for each OS distro/version and arch) and NodeJS (will be used to execute the test suite later).

## Tests
The playbook has been tested locally against real Windows EC2 instances.