### PR TITLE
Merge to main workflow

### DIFF
--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -62,8 +62,38 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
-      # TODO: fill with prod parameters when ready
-      #- name: Publish linux packages to production
+
+      - name: Publish linux packages to production
+        uses: newrelic/infrastructure-publish-action@v1.2.3
+        env:
+          TAG: ${{ needs.get-release-tag.outputs.tag }}
+          GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
+          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+          AWS_S3_BUCKET_NAME: "nr-downloads-ohai"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
+          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_PRODUCTION }}
+          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
+        with:
+          tag: ${{env.TAG}}
+          repo_name: "newrelic/fluent-bit-package"
+          schema: "custom"
+          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ env.TAG }}/generated-linux-schema.yaml"
+          aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          access_point_host: "staging"
+          run_id: ${{ github.run_id }}
+          aws_region: ${{ env.AWS_REGION }}
+          aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}
+          aws_role_arn: ${{ env.AWS_ROLE_ARN }}
+          # used for signing package stuff
+          gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
 
   publish-windows:
     name: Publish windows packages to logging's production bucket

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -6,29 +6,35 @@ on:
       - test_main
 
 jobs:
-  publishing-to-s3:
+  get-release-tag:
     name: Publish linux artifacts into s3 bucket
     runs-on: ubuntu-latest
-
+    outputs:
+      tag: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"
     steps:
       - name: Get PR number
         uses: actions/github-script@v6
         id: get_pr_number
         with:
           script: |
-              return (
-                await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  commit_sha: context.sha,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                })
-              ).data[0].number;
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0].number;
           result-encoding: string
 
-      - name: Publish packages
+  publish-linux:
+    name: Publish linux packages to staging and production buckets
+    needs: get-release-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish linux packages to staging
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
-          TAG: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"
+          TAG: ${{ needs.get-release-tag.outputs.tag }}"
           GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -23,5 +23,30 @@ jobs:
                 })
               ).data[0].number;
           result-encoding: string
-      - name: PR number
-        run: echo '${{steps.get_pr_number.outputs.result}}'
+
+      - name: Publish assets to windows S3
+        uses: newrelic/infrastructure-publish-action@v1.2.3
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+        with:
+          tag: ${{env.TAG}}
+          dest_prefix: "logging-test/"
+          repo_name: "newrelic/fluent-bit-package"
+          schema: "custom"
+          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/tmp-pr-${{ steps.get_pr_number.outputs.result }}/generated-linux-schema.yaml"
+          aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          access_point_host: "testing"
+          run_id: ${{ github.run_id }}
+          aws_region: ${{ env.AWS_REGION }}
+          aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}
+          aws_role_arn: ${{ env.AWS_ROLE_ARN }}
+          # used for signing package stuff
+          gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -3,7 +3,7 @@ name: Merge to master
 on:
   push:
     branches:
-      - test_main
+      - main
 
 jobs:
   get-release-tag:

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -6,12 +6,13 @@ on:
       - test_main
 
 jobs:
-  cd:
-    name: Promote pre-release to release and publish artifacts to production repositories
+  publishing-to-s3:
+    name: Publish linux artifacts into s3 bucket
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v6
+      - name: Get PR number
+        uses: actions/github-script@v6
         id: get_pr_number
         with:
           script: |
@@ -24,20 +25,20 @@ jobs:
               ).data[0].number;
           result-encoding: string
 
-      - name: Publish assets to windows S3
+      - name: Publish packages
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
           TAG: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"
           GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-          AWS_S3_BUCKET_NAME: "nr-downloads-main"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
+          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-testing"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-testing"
           AWS_REGION: "us-east-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_TESTING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_TESTING }}
+          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_TESTING }}
+          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_TESTING }}
         with:
           tag: ${{env.TAG}}
           dest_prefix: "logging-test/"

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish linux packages to staging
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
-          TAG: ${{ needs.get-release-tag.outputs.tag }}"
+          TAG: ${{ needs.get-release-tag.outputs.tag }}
           GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
@@ -62,3 +62,13 @@ jobs:
           # used for signing package stuff
           gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
           gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+      # TODO: fill with prod parameters when ready
+      #- name: Publish linux packages to production
+
+  publish-windows:
+    name: Publish windows packages to logging's production bucket
+    needs: get-release-tag
+    uses: ./.github/workflows/run_task.yml
+    with:
+      container_make_target: "ansible/upload-win-packages PR_TAG=${{ needs.get-release-tag.outputs.tag }}"
+    secrets: inherit

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -1,0 +1,27 @@
+name: Merge to master
+
+on:
+  push:
+    branches:
+      - test_main
+
+jobs:
+  cd:
+    name: Promote pre-release to release and publish artifacts to production repositories
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v6
+        id: get_pr_number
+        with:
+          script: |
+              return (
+                await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  commit_sha: context.sha,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                })
+              ).data[0].number;
+          result-encoding: string
+      - name: PR number
+        run: echo '${{steps.get_pr_number.outputs.result}}'

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -27,7 +27,13 @@ jobs:
       - name: Publish assets to windows S3
         uses: newrelic/infrastructure-publish-action@v1.2.3
         env:
-          TAG: ${{ github.event.inputs.tag }}
+          TAG: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"
+          GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
+          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+          AWS_S3_BUCKET_NAME: "nr-downloads-main"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
+          AWS_REGION: "us-east-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
           AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
@@ -37,7 +43,7 @@ jobs:
           dest_prefix: "logging-test/"
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
-          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/tmp-pr-${{ steps.get_pr_number.outputs.result }}/generated-linux-schema.yaml"
+          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ env.TAG }}/generated-linux-schema.yaml"
           aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}

--- a/.github/workflows/merge-to-master.yml
+++ b/.github/workflows/merge-to-master.yml
@@ -32,16 +32,15 @@ jobs:
           GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
           GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-testing"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-testing"
+          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
           AWS_REGION: "us-east-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_TESTING }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_TESTING }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_TESTING }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_TESTING }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
           tag: ${{env.TAG}}
-          dest_prefix: "logging-test/"
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ env.TAG }}/generated-linux-schema.yaml"
@@ -49,7 +48,7 @@ jobs:
           aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
           aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
-          access_point_host: "testing"
+          access_point_host: "staging"
           run_id: ${{ github.run_id }}
           aws_region: ${{ env.AWS_REGION }}
           aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -1,4 +1,4 @@
-name: Merge to master
+name: Merge to main
 
 on:
   push:

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -3,11 +3,11 @@ name: Merge to main
 on:
   push:
     branches:
-      - main
+      - test_main
 
 jobs:
   get-release-tag:
-    name: Gets pre-release tag of the recently merged PR
+    name: Gets pre-release tag commit associated with the merged PR
     runs-on: ubuntu-latest
     outputs:
       tag: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"
@@ -33,67 +33,43 @@ jobs:
     steps:
       - name: Publish linux packages to staging
         uses: newrelic/infrastructure-publish-action@v1.2.3
-        env:
-          TAG: ${{ needs.get-release-tag.outputs.tag }}
-          GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
-          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
-          AWS_REGION: "us-east-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
         with:
-          tag: ${{env.TAG}}
+          tag: ${{ needs.get-release-tag.outputs.tag }}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
-          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ env.TAG }}/generated-linux-schema.yaml"
-          aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ needs.get-release-tag.outputs.tag }}/generated-linux-schema.yaml"
+          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws_s3_bucket_name: "nr-downloads-ohai-staging"
+          aws_s3_lock_bucket_name: "onhost-ci-lock-staging"
           access_point_host: "staging"
           run_id: ${{ github.run_id }}
-          aws_region: ${{ env.AWS_REGION }}
-          aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}
-          aws_role_arn: ${{ env.AWS_ROLE_ARN }}
+          aws_region: "us-east-1"
+          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
           # used for signing package stuff
-          gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
-          gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
 
       - name: Publish linux packages to production
         uses: newrelic/infrastructure-publish-action@v1.2.3
-        env:
-          TAG: ${{ needs.get-release-tag.outputs.tag }}
-          GPG_MAIL: ${{ secrets.LOGGING_GPG_MAIL }}
-          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
-          AWS_S3_BUCKET_NAME: "nr-downloads-ohai"
-          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
-          AWS_REGION: "us-east-1"
-          AWS_ACCESS_KEY_ID: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
-          AWS_ROLE_ARN: ${{ secrets.OHAI_AWS_ROLE_ARN_PRODUCTION }}
-          AWS_ROLE_SESSION_NAME: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
         with:
-          tag: ${{env.TAG}}
+          tag: ${{ needs.get-release-tag.outputs.tag }}
           repo_name: "newrelic/fluent-bit-package"
           schema: "custom"
           schema_url: "https://github.com/newrelic/fluent-bit-package/releases/download/${{ env.TAG }}/generated-linux-schema.yaml"
-          aws_access_key_id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
-          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
+          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
+          aws_s3_bucket_name: "nr-downloads-ohai"
+          aws_s3_lock_bucket_name: "onhost-ci-lock"
           access_point_host: "staging"
           run_id: ${{ github.run_id }}
-          aws_region: ${{ env.AWS_REGION }}
-          aws_role_session_name: ${{ env.AWS_ROLE_SESSION_NAME }}
-          aws_role_arn: ${{ env.AWS_ROLE_ARN }}
+          aws_region: "us-east-1"
+          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
+          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_PRODUCTION }}
           # used for signing package stuff
-          gpg_passphrase: ${{ env.GPG_PASSPHRASE }}
-          gpg_private_key_base64: ${{ env.GPG_PRIVATE_KEY_BASE64 }}
+          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
 
   publish-windows:
     name: Publish windows packages to logging's production bucket

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -102,3 +102,23 @@ jobs:
     with:
       container_make_target: "ansible/upload-win-packages PR_TAG=${{ needs.get-release-tag.outputs.tag }}"
     secrets: inherit
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [get-release-tag,publish-linux,publish-windows]
+    steps:
+      - name: Send release details to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "releaseUrl": "https://github.com/newrelic/fluent-bit-package/releases/tag/${{ needs.get-release-tag.outputs.tag }}",
+              "releaseName": "${{ needs.get-release-tag.outputs.tag }}",
+              "productName": "${{ env.PRODUCT_NAME }}",
+              "productUrl": "${{ env.PRODUCT_URL }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PRODUCT_NAME: Fluent Bit packages for the New Relic Infrastructure Agent
+          PRODUCT_URL: https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -3,7 +3,7 @@ name: Merge to main
 on:
   push:
     branches:
-      - test_main
+      - main
 
 jobs:
   get-release-tag:

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   get-release-tag:
-    name: Publish linux artifacts into s3 bucket
+    name: Gets pre-release tag of the recently merged PR
     runs-on: ubuntu-latest
     outputs:
       tag: "tmp-pr-${{ steps.get_pr_number.outputs.result }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,6 +65,11 @@ jobs:
           echo "linux_and_windows_matrix=$( cat versions/linuxAndWindowsMatrix.json )" >> "$GITHUB_OUTPUT"
           echo "sles_matrix=$( cat versions/slesMatrix.json )" >> "$GITHUB_OUTPUT"
 
+      - name: Compute and upload schemas
+        run: |
+          make schemas;
+          gh release upload ${{ env.PRE_RELEASE_NAME }} schemas/generated-linux-schema.yaml --repo newrelic/fluent-bit-package
+
   # Downloads all Fluent Bit packages that are officially supported, preferably from the New Relic Infrastructure Agent
   # repository (Linux packages, already re-signed by NR) or Logging's S3 bucket (Windows packages, already packaged for the NRIA).
   # If these are not available, they are downloaded from the official Fluent Bit repository and repackaged to be used by the NRIA.

--- a/ansible/Ansible.common.mk
+++ b/ansible/Ansible.common.mk
@@ -26,10 +26,6 @@ ansible/dependencies: $(ROLES_PATH) $(COLLECTIONS_PATH)
 ansible/prepare-inventory:
 	@sed "s/PR_NUMBER/${PR_NUMBER}/g" $(ANSIBLE_INVENTORY_TEMPLATE) > $(ANSIBLE_INVENTORY)
 
-# Bundles the above
-.PHONY: ansible/common
-ansible/common: ansible/dependencies ansible/prepare-inventory
-
 # Removes "collections" and "roles" folders
 .PHONY: ansible/clean
 ansible/clean:

--- a/ansible/build-fb-suse/Makefile
+++ b/ansible/build-fb-suse/Makefile
@@ -3,7 +3,7 @@ include ../Ansible.common.mk
 .DEFAULT_GOAL := build-fb-suse
 
 .PHONY: build-fb-suse
-build-fb-suse: ansible/common
+build-fb-suse: ansible/dependencies ansible/prepare-inventory
 	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
 	@sed "s/PR_NUMBER/${PR_NUMBER}/g" playbook-localhost.yml.dist > playbook-localhost.yml
 	ansible-playbook $(ANSIBLE_FOLDER)/playbook-localhost.yml

--- a/ansible/build-fb-suse/playbook.yml
+++ b/ansible/build-fb-suse/playbook.yml
@@ -73,7 +73,6 @@
       command:
         cmd: ./configure
         chdir: "{{ bison_path }}"
-        creates: "{{ bison_path }}/Makefile"
 
     - name: Build Bison {{ bison_version }}
       community.general.make:
@@ -109,7 +108,6 @@
       command:
         cmd: "{{ cmake_path }}/bin/cmake -DCMAKE_INSTALL_PREFIX=/opt/fluent-bit/ -DCMAKE_INSTALL_SYSCONFDIR=/etc/ .."
         chdir: "{{ fluent_bit_path }}/build"
-        creates: "{{ fluent_bit_path }}/Makefile"
 
     - name: Build Fluent Bit {{ fluent_bit_version }}
       community.general.make:

--- a/ansible/provision-and-execute-tests/Makefile
+++ b/ansible/provision-and-execute-tests/Makefile
@@ -3,7 +3,7 @@ include ../Ansible.common.mk
 .DEFAULT_GOAL := provision-and-execute-tests
 
 .PHONY: provision-and-execute-tests
-provision-and-execute-tests: ansible/common
+provision-and-execute-tests: ansible/dependencies ansible/prepare-inventory
 	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
 
 .PHONY: clean

--- a/ansible/upload-win-packages/Makefile
+++ b/ansible/upload-win-packages/Makefile
@@ -1,0 +1,14 @@
+include ../Ansible.common.mk
+
+.DEFAULT_GOAL := upload-win-packages
+
+.PHONY: generateMatrix
+generateMatrix:
+	$(MAKE) -C ../../versions generateMatrices
+
+.PHONY: upload-win-packages
+upload-win-packages: ansible/dependencies generateMatrix
+	ansible-playbook $(ANSIBLE_FOLDER)/playbook.yml -i $(ANSIBLE_INVENTORY)
+
+.PHONY: clean
+clean: ansible/clean

--- a/ansible/upload-win-packages/playbook.yml
+++ b/ansible/upload-win-packages/playbook.yml
@@ -1,0 +1,26 @@
+- name: Upload windows packages
+  hosts: localhost
+  vars:
+    pr_tag: "{{ lookup('ansible.builtin.env', 'PR_TAG') }}"
+    windows_bucket: logging-fb-windows-packages
+    windows_matrix: "{{ lookup('file','../../versions/windowsMatrix.json') | from_json }}"
+  roles:
+    - andrewrothstein.gh
+  tasks:
+    - name: Set windows artifact names
+      set_fact:
+        windows_artifacts: "{{ windows_matrix | community.general.json_query('[*].targetPackageName') }}"
+
+    - name: Download windows artifacts from github pre_release
+      ansible.builtin.command: "gh release download {{ pr_tag }} --pattern '{{ item }}' --skip-existing"
+      loop: "{{ windows_artifacts }}"
+
+    - name: Upload windows artifacts
+      amazon.aws.s3_object:
+        bucket: "{{ windows_bucket }}"
+        object: "{{ item }}"
+        src: "{{ item }}"
+        mode: put
+        permission: public-read
+        purge_tags: false
+      loop: "{{ windows_artifacts }}"

--- a/ansible/upload-win-packages/requirements.yml
+++ b/ansible/upload-win-packages/requirements.yml
@@ -1,0 +1,5 @@
+collections:
+  - name: community.aws
+  - name: community.general
+roles:
+  - name: andrewrothstein.gh

--- a/schemas/Makefile
+++ b/schemas/Makefile
@@ -1,0 +1,5 @@
+.DEFAULT_GOAL := generateSchemas
+
+.PHONY: generateSchemas
+generateSchemas:
+	python3 schema.linux.py > generated-linux-schema.yaml

--- a/schemas/schema.linux.py
+++ b/schemas/schema.linux.py
@@ -7,21 +7,19 @@ if __name__ == '__main__':
     schemaObjectArray = []
     for item in matrixData:
         if item['osDistro'] != 'windows-server':
-            type = item['nrPackageUrl'].split('/')[5]
-            arch = 'arm64' if (item['arch'] == 'aarch64') else item['arch']
+            src = item['targetPackageName']
+            type = item['packageManagerType']
+            arch = item['repoArch']
+            os_version = item['osVersion']
             schemaObject = {
-                'src': item['targetPackageName'],
-                'arch': [
-                    arch
-                ],
+                'src': src,
+                'arch': [arch],
                 'uploads': [
                     {
                         'type': type,
                         'src_repo': '{access_point_host}/infrastructure_agent/linux/' + type,
                         'dest': '{dest_prefix}linux/' + type + '/',
-                        'os_version': [
-                            item['osVersion']
-                        ]
+                        'os_version': [os_version]
                     }
                 ]
             }

--- a/schemas/schema.linux.py
+++ b/schemas/schema.linux.py
@@ -1,0 +1,31 @@
+import json
+import yaml
+
+if __name__ == '__main__':
+    matrix = open('../versions/strategyMatrix.json')
+    matrixData = json.load(matrix)
+    schemaObjectArray = []
+    for item in matrixData:
+        if item['osDistro'] != 'windows-server':
+            type = item['nrPackageUrl'].split('/')[5]
+            arch = 'arm64' if (item['arch'] == 'aarch64') else item['arch']
+            schemaObject = {
+                'src': item['targetPackageName'],
+                'arch': [
+                    arch
+                ],
+                'uploads': [
+                    {
+                        'type': type,
+                        'src_repo': '{access_point_host}/infrastructure_agent/linux/' + type,
+                        'dest': '{dest_prefix}linux/' + type + '/',
+                        'os_version': [
+                            item['osVersion']
+                        ]
+                    }
+                ]
+            }
+            schemaObjectArray.append(schemaObject)
+
+    matrix.close()
+    print(yaml.dump(schemaObjectArray))

--- a/versions/Makefile
+++ b/versions/Makefile
@@ -6,3 +6,4 @@ generateMatrices:
 	python3 strategyMatrix.py > strategyMatrix.json
 	cat strategyMatrix.json | jq 'map(select(.osDistro == "sles"))' -c > slesMatrix.json
 	cat strategyMatrix.json | jq 'map(select(.osDistro != "sles"))' -c > linuxAndWindowsMatrix.json
+	cat strategyMatrix.json | jq 'map(select(.osDistro == "windows-server"))' -c > windowsMatrix.json

--- a/versions/strategyMatrix.py
+++ b/versions/strategyMatrix.py
@@ -38,6 +38,8 @@ This results in the following JSON objects in the resulting strategy matrix (rep
     "packageUrl": "https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-2.0.7-1.x86_64.rpm",
     "targetPackageName": "fluent-bit-2.0.7-1.centos-9.x86_64.rpm",
     "nrPackageUrl": "https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/el/9/x86_64/fluent-bit-2.0.7-1.centos-9.x86_64.rpm"
+    "repoArch": "x86_64",
+    "packageManagerType": "yum"
   },
   {
     "fbVersion": "2.0.6",
@@ -48,6 +50,8 @@ This results in the following JSON objects in the resulting strategy matrix (rep
     "packageUrl": "https://packages.fluentbit.io/centos/9/aarch64/fluent-bit-2.0.6-1.aarch64.rpm",
     "targetPackageName": "fluent-bit-2.0.6-1.centos-9.arm64.rpm",
     "nrPackageUrl": "https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/el/9/aarch64/fluent-bit-2.0.6-1.centos-9.arm64.rpm"
+    "repoArch": "arm64",
+    "packageManagerType": "yum"
   }
 
 This script file takes care of computing the following attributes for each supported package:
@@ -70,6 +74,8 @@ def deb_package_details(pkg):
         'targetPackageName': target_package_name,
         'nrPackageUrl':
 f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit/{target_package_name}",
+        'repoArch': f"{pkg['arch']}",
+        'packageManagerType': 'apt'
     }
 
 def rpm_package_details(pkg):
@@ -82,6 +88,8 @@ def rpm_package_details(pkg):
         'targetPackageName': target_package_name,
         'nrPackageUrl':
             f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/yum/{rpm_os_family}/{pkg['osVersion']}/{repo_arch}/{target_package_name}",
+        'repoArch': repo_arch,
+        'packageManagerType': 'yum'
     }
 
 def sles_package_details(pkg):
@@ -91,6 +99,8 @@ def sles_package_details(pkg):
         'targetPackageName': target_package_name,
         'nrPackageUrl':
             f"https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/linux/zypp/{pkg['osDistro']}/{pkg['osVersion']}/{pkg['arch']}/{target_package_name}",
+        'repoArch': f"{pkg['arch']}",
+        'packageManagerType': 'zypp'
     }
 
 def windows_package_details(data):


### PR DESCRIPTION
This PR adds a workflow when merging to `main`;
- Publish linux (staging & prod)
  - PR workflow add the schema file required to publish artifacts to CAOS repos
  - merge_to_main workflow uses that with `newrelic/infrastructure-publish-action@v1.2.3` to publish linux pkgs
- Publish windows
  - The matrix generates windows-only matrix
  - M2M workflow uses the matrix to fetch windows artifacts form the pre-release to then upload them to logging's s3 bucket