### PR TITLE
Notify only if a release was promoted

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -78,6 +78,8 @@ jobs:
     name: If there are packages in the pre_release, promote it to release
     needs: [ get_release_tag, run_e2e_tests_production ]
     runs-on: ubuntu-latest
+    outputs:
+      is_release: "${{ steps.promote_to_release.outputs.is_release }}"
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -85,19 +87,21 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check if pre_release has artifacts, if so, upgrade to release
+        id: promote_to_release
         run: |
           PR_NUMBER=${{ needs.get_release_tag.outputs.pr_number }}
           TAG=${{ needs.get_release_tag.outputs.tag }}
           PKG_COUNT=$(gh release view $TAG --repo newrelic/fluent-bit-package --json assets --jq '.assets[].name' | grep -E '^(fb-windows|fluent-bit)' | wc -l)
           if [[ $PKG_COUNT -gt 0 ]]
           then
-            echo "Promoting pre_release to release"
             gh release edit $TAG --draft=false --prerelease=false --title "Release $PR_NUMBER"
+            echo "is_release=true"
           fi
 
   notify:
     runs-on: ubuntu-latest
     needs: [ get_release_tag, promote_prerelease_to_release ]
+    if: ${{ needs.promote_prerelease_to_release.outputs.is_release == 'true' }}
     steps:
       - name: Send release details to Slack workflow
         id: slack


### PR DESCRIPTION
Only notify when a pre_release is promoted to release, which means there has been packages published. For the rest of PR's, like adding tests or fixing vulnerabilities or optimizing an ansible playbook it does not make sense to notify anything, since no new package is built nor published.