### PR TITLE
Instrument with custom event

### DIFF
--- a/.github/workflows/new_relic.yml
+++ b/.github/workflows/new_relic.yml
@@ -41,14 +41,16 @@ jobs:
           run_number="${{ github.event.workflow_run.run_number }}"
           html_url="${{ github.event.workflow_run.html_url }}"
           
-          WORKFLOW_RUN_DETAILS=$(jq -n \
+          echo $(jq -n \
             --arg id "$id" \
             --arg workflow_name "$workflow_name" \
             --arg conclusion "$conclusion" \
             --arg run_number "$run_number" \
             --arg html_url "$html_url" \
-          '{id: $id, workflow_name: $workflow_name, conclusion: $conclusion, run_number: $run_number, html_url: $html_url }')
+          '{id: $id, workflow_name: $workflow_name, conclusion: $conclusion, run_number: $run_number, html_url: $html_url }') \
+          > workflow_run.json
 
-          gzip -c $WORKFLOW_RUN_DETAILS | curl -X POST -H "Content-Type: application/json" \
+
+          gzip -c workflow_run.json | curl -X POST -H "Content-Type: application/json" \
           -H "Api-Key: ${{ env.NEW_RELIC_LICENSE_KEY }}" -H "Content-Encoding: gzip" \
           https://staging-insights-collector.newrelic.com/v1/accounts/${{ env.NEW_RELIC_ACCOUNT_ID }}/events --data-binary @-


### PR DESCRIPTION
We leveraged [newrelic-experimental/gha-new-relic-exporter](https://github.com/newrelic-experimental/gha-new-relic-exporter), but it seems to be a work in progress since we could not reliably get the failures of the workflows.

Instead of removing it, hoping that at some point we can leverage it (it is amazing!), we decided to report simpler `workflow_run` status for `Pull Request` and `Merge to main` workflows in the form of a custom event.

We can reliably use these to detect failures!