### PR TITLE
Removed pinned 2.2.2 fb version for linux 2023

### DIFF
--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,6 +1,5 @@
 osDistro: amazonlinux
 osVersion: 2023
-fbVersion: 2.2.2
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,6 +1,6 @@
 osDistro: amazonlinux
 osVersion: 2023
-fbVersion: 3.0.4
+fbVersion: 3.0.2
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,5 +1,6 @@
 osDistro: amazonlinux
 osVersion: 2023
+fbVersion: 3.0.4
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,6 +1,5 @@
 osDistro: amazonlinux
 osVersion: 2023
-fbVersion: 3.0.2
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475


### PR DESCRIPTION
Removed pinned 2.2.2 fb version for linux 2023 due to this fb 3.0.3 is not available in IA for linux 2023 .
