### PR TITLE
Add Ubuntu 24.04 FB packages

### DIFF
--- a/ansible/build-fb-suse/requirements.yml
+++ b/ansible/build-fb-suse/requirements.yml
@@ -1,7 +1,7 @@
 collections:
   - name: community.aws
   - name: community.general
-  - name: git+https://github.com/luckslovez/caos-ansible-roles.git#/caos.ansible_roles/
+  - name: git+https://github.com/Sivakumar3695/caos-ansible-roles#/caos.ansible_roles/
     type: git
 roles:
   - name: andrewrothstein.gh

--- a/ansible/provision-and-execute-tests/requirements.yml
+++ b/ansible/provision-and-execute-tests/requirements.yml
@@ -6,7 +6,7 @@ collections:
     version: 2.11.0
   - name: chocolatey.chocolatey
     version: 1.5.1
-  - name: git+https://github.com/luckslovez/caos-ansible-roles.git#/caos.ansible_roles/
+  - name: git+https://github.com/Sivakumar3695/caos-ansible-roles#/caos.ansible_roles/
     type: git
 
 roles:

--- a/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
+++ b/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 %{if os_distro == "centos"}
+%{if os_version == 8}
+sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+sudo dnf distro-sync
+%{endif}
 sudo %{if os_version == 7}yum%{else}dnf%{endif} install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_%{if arch == "x86_64"}amd64%{else}arm64%{endif}/amazon-ssm-agent.rpm
 %{endif}
 

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -1,6 +1,5 @@
 osDistro: amazonlinux
 osVersion: 2023
-fbVersion: 2.2.2
 packages:
   - arch: x86_64
     ami: ami-01103fb68b3569475

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,4 +1,4 @@
-fbVersion: 3.0.4
+fbVersion: 3.0.6
 
 #  This file, together with each distro file are processed and merged incrementally to
 #  build all the information required to download and test each package. Each package ends

--- a/versions/ubuntu_24_noble.yml
+++ b/versions/ubuntu_24_noble.yml
@@ -2,6 +2,6 @@ osDistro: ubuntu
 osVersion: noble
 packages:
   - arch: amd64
-    ami: ami-08523f0f4ee29dbfc
+    ami: ami-09040d770ffe2224f
   - arch: arm64
-    ami: ami-092c6102f0e2fb797
+    ami: ami-001f73ecbd4409f82

--- a/versions/ubuntu_24_noble.yml
+++ b/versions/ubuntu_24_noble.yml
@@ -1,0 +1,7 @@
+osDistro: ubuntu
+osVersion: noble
+packages:
+  - arch: amd64
+    ami: ami-08523f0f4ee29dbfc
+  - arch: arm64
+    ami: ami-092c6102f0e2fb797


### PR DESCRIPTION
Changes:
1. Upgraded FB to v3.0.6
2. Supported Ubuntu 24.04 (Noble Numbat) for: 
     a. amd64
     b. arm64