### PR TITLE
Upgrade fluent bit version to 3.1.9

### DIFF
--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,4 +1,4 @@
-fbVersion: 3.1.2
+fbVersion: 3.1.9
 
 #  This file, together with each distro file are processed and merged incrementally to
 #  build all the information required to download and test each package. Each package ends


### PR DESCRIPTION
Upgrade fluent bit version to 3.1.9  , to resolve the vulnerabilities with trivy image [cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit](http://cf-registry.nr-ops.net/maas/docker-atlantis-fluent-bit)