### PR TITLE
uncomment always() in tear_down_test_executor_instances. 

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -99,7 +99,7 @@ jobs:
 
   tear_down_test_executor_instances:
     name: Tear down test executor instances
-    #if: always() #Uncomment after 3.1.9 version release
+    if: always()
     needs: report_test_results
     uses: ./.github/workflows/run_task.yml
     with:


### PR DESCRIPTION
this PR contains 

Uncomment always() condition in tear_down_test_executor_instances, which we have commented when upgrading fluent bit version as workflows were flaky and we needed to re-run the job many times.