### PR TITLE
Fluent bit 5.0.6 upgrade

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,7 @@ permissions:
   packages: write
   id-token: write
   checks: write
+  pull-requests: write
 
 on: [pull_request]
 

--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   id-token: write
   checks: write
+  pull-requests: write
 
 on:
   # To be able to launch it from pull_request.yml programmatically

--- a/.github/workflows/run_prerelease.yml
+++ b/.github/workflows/run_prerelease.yml
@@ -5,6 +5,7 @@ permissions:
   packages: write
   id-token: write
   checks: write
+  pull-requests: write
 
 on:
   # To be able to launch it from pull_request.yml programmatically

--- a/versions/amazonlinux_2.yml
+++ b/versions/amazonlinux_2.yml
@@ -2,6 +2,6 @@ osDistro: amazonlinux
 osVersion: 2
 packages:
   - arch: x86_64
-    ami: ami-05e1405c57ab23683
+    ami: ami-0681f53b4961a7296
   - arch: aarch64
-    ami: ami-08d8cbe09f0a01184
+    ami: ami-09dacf8da1ed712f1

--- a/versions/amazonlinux_2023.yml
+++ b/versions/amazonlinux_2023.yml
@@ -2,6 +2,6 @@ osDistro: amazonlinux
 osVersion: 2023
 packages:
   - arch: x86_64
-    ami: ami-0b4624933067d393a
+    ami: ami-02f986bab3de34d0d
   - arch: aarch64
-    ami: ami-00136537838fffb8e
+    ami: ami-0d62c32deead0d6c5

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,4 +1,4 @@
-fbVersion: 4.2.2
+fbVersion: 5.0.6
 
 # New Relic Fluent Bit Output Plugin Configuration
 # These values are used during E2E testing to download and test a specific version of the NR output plugin

--- a/versions/windows-server-2019.yml
+++ b/versions/windows-server-2019.yml
@@ -2,7 +2,7 @@ osDistro: windows-server
 osVersion: 2019
 packages:
   - arch: win64
-    ami: ami-0d1b30a19661df9bd
+    ami: ami-097844465530c45f8
   # There is no win32 image available in AWS, so we use the w64 one to test the w32 binaries
   - arch: win32
-    ami: ami-0d1b30a19661df9bd
+    ami: ami-097844465530c45f8

--- a/versions/windows-server-2022.yml
+++ b/versions/windows-server-2022.yml
@@ -2,6 +2,6 @@ osDistro: windows-server
 osVersion: 2022
 packages:
   - arch: win64
-    ami: ami-043caaf4b51d812c1
+    ami: ami-0e7995aec6c9b24c0
   - arch: win32
-    ami: ami-043caaf4b51d812c1
+    ami: ami-0e7995aec6c9b24c0


### PR DESCRIPTION
Changes:
* Bumped Fluent Bit version 4.2.2 → 5.0.6 in common.yml.
* Added **pull-requests: write** permission in pull_request.yml, run_e2e_tests.yml, run_prerelease.yml to fix 403 from the test-result publish action.
* Refreshed AMI IDs for E2E test executors in amazonlinux_2.yml, amazonlinux_2023.yml, windows-server-2019.yml, windows-server-2022.yml.
