### PR TITLE
ci: grant pull-requests:write to merge_to_main

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -2,7 +2,7 @@ name: Merge to main
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
   id-token: write
   checks: write
 


### PR DESCRIPTION
### Problem

After merging #239 (Fluent Bit 5.0.6 upgrade), the `Merge to main` workflow failed immediately with `startup_failure`:

> Invalid workflow file: `.github/workflows/merge_to_main.yml#L64`
> The workflow is requesting `pull-requests: write`, but is only allowed `pull-requests: read`.

Failed run: https://github.com/newrelic/fluent-bit-package/actions/runs/26934513835

As a result, the 5.0.6 packages were **not published to production**, and the GitHub pre-release `tmp-pr-239` was never promoted to a GA release.

### Root cause

In #239 we added `pull-requests: write` to the reusable workflow `run_e2e_tests.yml` so that `EnricoMi/publish-unit-test-result-action` can post sticky test-result comments on PRs (it was previously hitting 403 with `read`).

GitHub Actions enforces a rule for reusable workflows: **the caller must grant at least as many permissions as the callee declares**. The PR-side caller (`pull_request.yml`) was bumped to `write` in #239, but the main-side caller (`merge_to_main.yml`) was missed and still grants only `read`.

This makes the entire `Merge to main` workflow invalid at validation time → 0-second `startup_failure`, no jobs execute.

### Fix

One-line change in `merge_to_main.yml` change pull-requests: read to pull-requests: write