### PR TITLE
Add Ubuntu 26.04 (resolute) Support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,6 +35,8 @@ jobs:
       linux_and_windows_matrix: ${{ steps.set-matrices.outputs.linux_and_windows_matrix }}
       linux_and_windows_unique_target_package : ${{ steps.set-matrices.outputs.linux_and_windows_unique_target_package }}
       windows_matrix: ${{ steps.set-matrices.outputs.windows_matrix }}
+      apt_matrix: ${{ steps.set-matrices.outputs.apt_matrix }}
+      yum_matrix: ${{ steps.set-matrices.outputs.yum_matrix }}
     steps:
       - name: Checkout code
         # commit sha from v3 tag - verify with: git ls-remote https://github.com/actions/checkout v3
@@ -77,6 +79,8 @@ jobs:
           echo "linux_and_windows_unique_target_package=$(echo $filtered_json)" >> "$GITHUB_OUTPUT"
           echo "sles_matrix=$( cat versions/slesMatrix.json )" >> "$GITHUB_OUTPUT"
           echo "windows_matrix=$( cat versions/windowsMatrix.json )" >> "$GITHUB_OUTPUT"
+          echo "apt_matrix=$( cat versions/aptMatrix.json )" >> "$GITHUB_OUTPUT"
+          echo "yum_matrix=$( cat versions/yumMatrix.json )" >> "$GITHUB_OUTPUT"
           gh release upload ${{ env.PRE_RELEASE_NAME }} versions/linuxAndWindowsMatrix.json --repo newrelic/fluent-bit-package
           gh release upload ${{ env.PRE_RELEASE_NAME }} versions/slesMatrix.json --repo newrelic/fluent-bit-package
 
@@ -196,6 +200,8 @@ jobs:
       sles_matrix: ${{ needs.setup_environment.outputs.sles_matrix }}
       pre_release_name: ${{ needs.setup_environment.outputs.pre_release_name }}
       windows_matrix: ${{ needs.setup_environment.outputs.windows_matrix }}
+      apt_matrix: ${{ needs.setup_environment.outputs.apt_matrix }}
+      yum_matrix: ${{ needs.setup_environment.outputs.yum_matrix }}
       nr_fb_output_plugin_version: ${{ needs.setup_environment.outputs.nr_fb_output_plugin_version }}
       nr_fb_output_plugin_tag: ${{ needs.setup_environment.outputs.nr_fb_output_plugin_tag }}
       cleanup_on_failure: ${{ needs.setup_environment.outputs.always_cleanup_test_instances == 'true' }}  # Convert string to boolean - Read from versions/common.yml (alwaysCleanupTestInstances)

--- a/.github/workflows/run_prerelease.yml
+++ b/.github/workflows/run_prerelease.yml
@@ -38,6 +38,16 @@ on:
         description: Matrix of Windows distros, versions, and architectures to run the tests on
         required: false
         type: string
+      apt_matrix:
+        description: Matrix of APT distros (debian, ubuntu) to run the tests on. Empty list skips APT jobs.
+        required: false
+        default: '[]'
+        type: string
+      yum_matrix:
+        description: Matrix of YUM distros (amazonlinux, centos, rockylinux) to run the tests on. Empty list skips YUM jobs.
+        required: false
+        default: '[]'
+        type: string
       linux_test_report_name:
         description: Linux test report name
         required: false
@@ -89,6 +99,16 @@ on:
       windows_matrix:
         description: Matrix of Windows distros, versions, and architectures to run the tests on
         required: false
+        type: string
+      apt_matrix:
+        description: Matrix of APT distros (debian, ubuntu) to run the tests on. Empty list skips APT jobs.
+        required: false
+        default: '[]'
+        type: string
+      yum_matrix:
+        description: Matrix of YUM distros (amazonlinux, centos, rockylinux) to run the tests on. Empty list skips YUM jobs.
+        required: false
+        default: '[]'
         type: string
       linux_test_report_name:
         description: Linux test report name
@@ -203,7 +223,8 @@ jobs:
     name: Provision APT distros (debian, ubuntu)
     needs: [ spin_up_test_executor_instances ]
     if: ${{ always() && !failure() && !cancelled()
-      && (needs.spin_up_test_executor_instances.result == 'success' || needs.spin_up_test_executor_instances.result == 'skipped')}}
+      && (needs.spin_up_test_executor_instances.result == 'success' || needs.spin_up_test_executor_instances.result == 'skipped')
+      && inputs.apt_matrix != '[]' }}
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "ansible/provision-and-execute-tests/${{ inputs.infra_agent_env }}-linux-provision-apt PRE_RELEASE_NAME=${{ inputs.gh_release_name }} NR_FB_OUTPUT_PLUGIN_VERSION=${{ inputs.nr_fb_output_plugin_version }} NR_FB_OUTPUT_PLUGIN_TAG=${{ inputs.nr_fb_output_plugin_tag }}"
@@ -213,7 +234,8 @@ jobs:
     name: Provision YUM distros (amazonlinux, centos, rocky)
     needs: [ spin_up_test_executor_instances ]
     if: ${{ always() && !failure() && !cancelled()
-      && (needs.spin_up_test_executor_instances.result == 'success' || needs.spin_up_test_executor_instances.result == 'skipped')}}
+      && (needs.spin_up_test_executor_instances.result == 'success' || needs.spin_up_test_executor_instances.result == 'skipped')
+      && inputs.yum_matrix != '[]' }}
     uses: ./.github/workflows/run_task.yml
     with:
       container_make_target: "ansible/provision-and-execute-tests/${{ inputs.infra_agent_env }}-linux-provision-yum PRE_RELEASE_NAME=${{ inputs.gh_release_name }} NR_FB_OUTPUT_PLUGIN_VERSION=${{ inputs.nr_fb_output_plugin_version }} NR_FB_OUTPUT_PLUGIN_TAG=${{ inputs.nr_fb_output_plugin_tag }}"

--- a/ansible/provision-and-execute-tests/playbook-provision-prerelease.yml
+++ b/ansible/provision-and-execute-tests/playbook-provision-prerelease.yml
@@ -7,6 +7,28 @@
     ansible_aws_ssm_timeout: 900
     ansible_aws_ssm_retries: 10
   tasks:
+    # Ubuntu 26.04 (resolute) uses sudo-rs, whose use_pty default breaks Ansible
+    # `become` over the SSM connection (it can't tell when a sudo command finished).
+    # Terraform writes this fix at boot, but CI instances don't always receive
+    # user_data - so write it here too, via a raw `become` (which still works while
+    # use_pty is on), before the first sudo task. Resolute only; safe to re-run.
+    - name: "PRE | wait for plain (non-become) connectivity"
+      become: false
+      when: tags.os_distro == 'ubuntu' and tags.os_version == 'resolute'
+      ansible.builtin.wait_for_connection:
+        delay: 5
+        timeout: 180
+
+    - name: "PRE | bootstrap: disable sudo use_pty (raw become, idempotent)"
+      become: true
+      when: tags.os_distro == 'ubuntu' and tags.os_version == 'resolute'
+      timeout: 90
+      changed_when: false
+      failed_when: false
+      ignore_unreachable: true
+      ansible.builtin.raw: |
+        test -f /etc/sudoers.d/99-disable-use-pty || { echo 'Defaults !use_pty' > /etc/sudoers.d/99-disable-use-pty && chmod 440 /etc/sudoers.d/99-disable-use-pty; }
+
     - name: Establish initial connection to host
       block:
         - name: Wait for connection to be available

--- a/ansible/provision-and-execute-tests/playbook-provision-repo.yml
+++ b/ansible/provision-and-execute-tests/playbook-provision-repo.yml
@@ -11,6 +11,25 @@
   become: true
   gather_facts: no
   tasks:
+    # Same sudo-rs use_pty fix as the prerelease playbook: write the !use_pty
+    # drop-in via a raw `become` before the first sudo task. Resolute only; safe to re-run.
+    - name: "PRE | non-become connectivity"
+      become: false
+      when: tags.os_distro == 'ubuntu' and tags.os_version == 'resolute'
+      ansible.builtin.wait_for_connection:
+        delay: 5
+        timeout: 180
+
+    - name: "PRE | bootstrap disable sudo use_pty (raw become, idempotent)"
+      become: true
+      when: tags.os_distro == 'ubuntu' and tags.os_version == 'resolute'
+      timeout: 90
+      changed_when: false
+      failed_when: false
+      ignore_unreachable: true
+      ansible.builtin.raw: |
+        test -f /etc/sudoers.d/99-disable-use-pty || { echo 'Defaults !use_pty' > /etc/sudoers.d/99-disable-use-pty && chmod 440 /etc/sudoers.d/99-disable-use-pty; }
+
     - name: Establish initial connection to host
       block:
         - name: Wait for connection to be available

--- a/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/apt.yml
+++ b/ansible/provision-and-execute-tests/roles/install_fluent_bit_from_gh_prerelease/tasks/apt.yml
@@ -25,6 +25,8 @@
     deb: "/tmp/{{ fb_package_name }}"
     # We want our package to overwrite the one that comes with the Infra Agent, even if it implies downgrading it
     allow_downgrade: true
+    # Refresh apt index so deps resolve (arm64 resolute: libpq5).
+    update_cache: true
     state: present
   register: install_result
   until: install_result is succeeded

--- a/terraform/ec2-instances-creator/main.tf
+++ b/terraform/ec2-instances-creator/main.tf
@@ -85,7 +85,10 @@ module "ec2_instance" {
     )
   )
 
-  user_data = contains(local.os_distros_requiring_user_data_script_for_ssm, each.value.osDistro) ? templatefile(local.user_data_script_for_ssm_path, { os_distro = each.value.osDistro, arch = each.value.arch, os_version = each.value.osVersion }) : null
+  # Ubuntu 26.04 (resolute) needs this user_data too: it ships sudo-rs, whose use_pty
+  # default breaks Ansible `become` over the SSM connection (details in the .tftpl).
+  # All other distros/versions are unchanged.
+  user_data = (contains(local.os_distros_requiring_user_data_script_for_ssm, each.value.osDistro) || (each.value.osDistro == "ubuntu" && each.value.osVersion == "resolute")) ? templatefile(local.user_data_script_for_ssm_path, { os_distro = each.value.osDistro, arch = each.value.arch, os_version = each.value.osVersion }) : null
 
   # Include fields from the strategy matrix into the EC2 instance tags. Thanks to this, we are able to know which Fluent
   # Bit version and for which OS version and arch is each EC2 instance meant to compile/test. This is later read in the

--- a/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
+++ b/terraform/ec2-instances-creator/user_data_script_for_ssm.tftpl
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+%{if os_distro == "ubuntu" && os_version == "resolute"}
+# Ubuntu 26.04 (resolute) uses sudo-rs (the new Rust sudo). By default it runs each
+# command in its own terminal (use_pty); over the SSM connection that stops Ansible
+# from detecting when a `sudo` command finished, so every become task times out and
+# the host shows UNREACHABLE. Turning use_pty off fixes it. Harmless on classic sudo.
+echo 'Defaults !use_pty' > /etc/sudoers.d/99-disable-use-pty
+chmod 440 /etc/sudoers.d/99-disable-use-pty
+%{endif}
+
 %{if os_distro == "centos" || os_distro == "rockylinux"}
 %{if os_version == 7}
 sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
@@ -21,5 +30,7 @@ wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_${arc
 sudo dpkg -i amazon-ssm-agent.deb
 %{endif}
 
+%{if !(os_distro == "ubuntu" && os_version == "resolute")}
 systemctl enable amazon-ssm-agent
 systemctl start amazon-ssm-agent
+%{endif}

--- a/versions/Makefile
+++ b/versions/Makefile
@@ -7,6 +7,8 @@ generateMatrices:
 	cat prodAndStagingMatrix.json | jq 'map(select(.osDistro == "sles"))' -c > slesMatrix.json
 	cat prodAndStagingMatrix.json | jq 'map(select(.osDistro != "sles"))' -c > linuxAndWindowsMatrix.json
 	cat prodAndStagingMatrix.json | jq 'map(select(.osDistro == "windows-server"))' -c > windowsMatrix.json
+	cat prodAndStagingMatrix.json | jq 'map(select(.osDistro == "debian" or .osDistro == "ubuntu"))' -c > aptMatrix.json
+	cat prodAndStagingMatrix.json | jq 'map(select(.osDistro == "amazonlinux" or .osDistro == "centos" or .osDistro == "rockylinux"))' -c > yumMatrix.json
 	# used to generate proper schemas in schema.linux.py
 	cat strategyMatrix.json | jq 'map(select(.isStaging == false))' -c > stagingMatrix.json
 	cat strategyMatrix.json | jq 'map(select(.isProduction == false))' -c > productionMatrix.json

--- a/versions/ubuntu_26_resolute.yml
+++ b/versions/ubuntu_26_resolute.yml
@@ -1,0 +1,7 @@
+osDistro: ubuntu
+osVersion: resolute
+packages:
+  - arch: amd64
+    ami: ami-0fe18bc3cfa53a248
+  - arch: arm64
+    ami: ami-005e7d5b13cc4b72b


### PR DESCRIPTION
# What this PR does
Adds Ubuntu 26.04 (resolute) support to the build/test pipeline.

# Changes

1. Add resolute to the version matrix — new versions/ubuntu_26_resolute.yml so it gets built and tested (amd64 + arm64).
2. Per-family APT/YUM job gating — split the matrix into aptMatrix/yumMatrix and run each family's e2e jobs only when it has distros. (Resolute is APT-only, so the empty YUM jobs skip instead of failing.)
3. sudo-rs use_pty fix (resolute only) — Ubuntu 26.04 ships sudo-rs, whose use_pty default breaks Ansible become over the SSM connection. Disable it via a boot-time user_data drop-in plus a raw-become bootstrap in the provision playbooks.
4. apt cache refresh — run apt-get update before installing the fluent-bit .deb so arm64 dependencies (libpq5) resolve.