### PR TITLE
Bump fluent-bit to 5.0.8 and NR output plugin to 3.7.0

### DIFF
--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,4 +1,4 @@
-fbVersion: 5.0.6
+fbVersion: 5.0.8
 
 # New Relic Fluent Bit Output Plugin Configuration
 # These values are used during E2E testing to download and test a specific version of the NR output plugin

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -2,7 +2,7 @@ fbVersion: 5.0.6
 
 # New Relic Fluent Bit Output Plugin Configuration
 # These values are used during E2E testing to download and test a specific version of the NR output plugin
-nrFbOutputPluginVersion: 3.4.0
+nrFbOutputPluginVersion: 3.7.0
 # Optional: Override the GitHub release tag (defaults to v{nrFbOutputPluginVersion} if not set)
 # Use this for custom/beta releases where the tag differs from the standard v{version} format
 # Example for beta: nrFbOutputPluginTag: newrelic-fluent-bit-output-3.3.1-beta-rhel8-test


### PR DESCRIPTION
## Summary
- Update `fbVersion` from 5.0.6 to 5.0.8
- Update `nrFbOutputPluginVersion` from 3.4.0 to 3.7.0

## Test plan
- [ ] CI pipeline passes with updated versions
- [ ] E2E tests validate the new plugin version