### PR TITLE
Bump fluent-bit to 5.0.8 and NR output plugin to 3.7.0

### DIFF
--- a/versions/centos_9.yml
+++ b/versions/centos_9.yml
@@ -4,4 +4,4 @@ packages:
   - arch: x86_64
     ami: ami-0008a45426822f82f
   - arch: aarch64
-    ami: ami-0a0083d5b697457a6
+    ami: ami-0056c0bf0ae11619c

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -1,4 +1,4 @@
-fbVersion: 5.0.6
+fbVersion: 5.0.8
 
 # New Relic Fluent Bit Output Plugin Configuration
 # These values are used during E2E testing to download and test a specific version of the NR output plugin

--- a/versions/common.yml
+++ b/versions/common.yml
@@ -2,7 +2,7 @@ fbVersion: 5.0.6
 
 # New Relic Fluent Bit Output Plugin Configuration
 # These values are used during E2E testing to download and test a specific version of the NR output plugin
-nrFbOutputPluginVersion: 3.4.0
+nrFbOutputPluginVersion: 3.7.0
 # Optional: Override the GitHub release tag (defaults to v{nrFbOutputPluginVersion} if not set)
 # Use this for custom/beta releases where the tag differs from the standard v{version} format
 # Example for beta: nrFbOutputPluginTag: newrelic-fluent-bit-output-3.3.1-beta-rhel8-test

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -1,7 +1,0 @@
-osDistro: debian
-osVersion: bullseye
-packages:
-  - arch: amd64
-    ami: ami-0c18857b85f7df9ca
-  - arch: arm64
-    ami: ami-00ae926787c25569b

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -1,0 +1,7 @@
+osDistro: debian
+osVersion: bullseye
+packages:
+  - arch: amd64
+    ami: ami-0c18857b85f7df9ca
+  - arch: arm64
+    ami: ami-00ae926787c25569b

--- a/versions/debian_11_bullseye.yml
+++ b/versions/debian_11_bullseye.yml
@@ -2,6 +2,6 @@ osDistro: debian
 osVersion: bullseye
 packages:
   - arch: amd64
-    ami: ami-0c18857b85f7df9ca
+    ami: ami-0962adcff33d31b18
   - arch: arm64
-    ami: ami-00ae926787c25569b
+    ami: ami-0d472c931a509a34c


### PR DESCRIPTION
- **Bump fluent-bit to 5.0.8 and NR output plugin to 3.7.0**
- **Update fbVersion to 5.0.8**
- **Remove Debian 11 (Bullseye) support — EOL since 2026-06-30**
